### PR TITLE
Fixes for ubuntu server installation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,8 @@ default['icinga2']['service_name'] = 'icinga2'
 case node['platform_family']
 when 'rhel'
 
+	default['icinga2']['user'] = 'icinga'
+	default['icinga2']['group'] = 'icinga'
   default['icinga2']['service_config_file'] = '/etc/sysconfig/icinga2'
 
   case node['kernel']['machine']
@@ -71,6 +73,8 @@ when 'rhel'
   end
 
 when 'debian'
+	default['icinga2']['user'] = 'nagios'
+	default['icinga2']['group'] = 'nagios'
   default['icinga2']['service_config_file'] = '/etc/default/icinga2'
   default['icinga2']['plugins_dir'] = '/usr/lib/nagios/plugins'
 end
@@ -78,8 +82,6 @@ end
 default['icinga2']['custom_plugins_dir'] = '/opt/icinga2_custom_plugins'
 
 default['icinga2']['admin_user'] = 'icingaadmin'
-default['icinga2']['user'] = 'icinga'
-default['icinga2']['group'] = 'icinga'
 default['icinga2']['cmdgroup'] = 'icingacmd'
 
 # ulimit

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,6 +17,13 @@
 # limitations under the License.
 #
 
+# Platform specific preparations
+case node['platform_family']
+when	'debian'
+	include_recipe 'apt'
+else
+end
+
 include_recipe 'icinga2::server_os_packages'
 
 # setup apache and icinga2 vhost


### PR DESCRIPTION
Bug report
Ubuntu 14.04 kitchen tests:
Ubuntu: Server installatoin fails because apt_package[php5]fails.

  * apt_package[php5] action install [2015-01-16T10:12:47+00:00] INFO: Processing apt_package[php5] action install (icinga2::server_os_packages line 29)
           ================================================================================
           Error executing action `install` on resource 'apt_package[php5]'
           ================================================================================

Possible fix would be to include apt recipe.
Ubuntu: 
 * template[/etc/icinga2/icinga2.conf] action create[2015-01-16T10:22:29+00:00] INFO: Processing template[/etc/icinga2/icinga2.conf] action create (icinga2::server_core line 61)       
       
           * cannot determine user id for 'icinga', does the user exist on this system?
       
    ================================================================================       
           Error executing action `create` on resource 'template[/etc/icinga2/icinga2.conf]'
    ================================================================================ 
Fixed wit changed defautl runuser and rungroup 'nagios'.



