### PR TITLE
fix package version for release repo

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -22,7 +22,7 @@ default['icinga2']['apt']['action'] = :add
 
 # icinga2 package version suffix
 default['icinga2']['icinga2_version_suffix'] = value_for_platform(
-  %w(centos redhat fedora) => { 'default' => ".el#{node['platform_version']}" },
+  %w(centos redhat fedora) => { 'default' => ".el#{node['platform_version'].split('.')[0]}" },
   'amazon' => { 'default' => '.el6' },
   'ubuntu' => { 'default' => '~ppa1~' + node['lsb']['codename'].to_s + '1' }
 )


### PR DESCRIPTION
For CentOS 6 platform_version return '6.6' but packages in official repo has release '1-el6' like "icinga2-2.2.3-1.el6.x86_64"
This patch fix this problem.