### PR TITLE
move icinga features in definiton

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -22,7 +22,7 @@ default['icinga2']['apt']['action'] = :add
 
 # icinga2 package version suffix
 default['icinga2']['icinga2_version_suffix'] = value_for_platform(
-  %w(centos redhat fedora) => { 'default' => ".el#{node['platform_version']}" },
+  %w(centos redhat fedora) => { 'default' => ".el#{node['platform_version'].split('.')[0]}" },
   'amazon' => { 'default' => '.el6' },
   'ubuntu' => { 'default' => '~ppa1~' + node['lsb']['codename'].to_s + '1' }
 )

--- a/definitions/icinga2_feature.rb
+++ b/definitions/icinga2_feature.rb
@@ -1,0 +1,49 @@
+#
+# Cookbook Name:: icinga2
+# Definition:: icinga_feature
+#
+# Copyright 2008-20013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'pp'
+
+define :icinga2_feature, :enable => true, :conf => false do
+
+  if params[:conf]
+    template "#{node['icinga2']['conf_dir']}/features-available/#{params[:name]}.conf" do
+      cookbook params[:cookbook] if params[:cookbook]
+      source "#{params[:name]}.conf.erb"
+      owner node['icinga2']['user']
+      group node['icinga2']['group']
+      mode '0640'
+      variables(:params => params)
+      notifies :reload, 'service[icinga2]', :delayed
+    end
+  end
+
+  if params[:enable]
+    execute "enable_feature_#{params[:name]}" do
+      command "/usr/sbin/icinga2 feature enable #{params[:name]}"
+      notifies :reload, 'service[icinga2]', :delayed
+      not_if { ::File.symlink?(::File.join(node['icinga2']['features_enabled_dir'], "#{params[:name]}.conf")) }
+    end
+  else
+    execute "disable_feature_#{params[:name]}" do
+      command "/usr/sbin/icinga2 feature disable #{params[:name]}"
+      notifies :reload, 'service[icinga2]', :delayed
+      only_if { ::File.symlink?(::File.join(node['icinga2']['features_enabled_dir'], "#{params[:name]}.conf")) }
+    end
+  end
+end

--- a/recipes/server_features.rb
+++ b/recipes/server_features.rb
@@ -18,19 +18,12 @@
 #
 
 node['icinga2']['enable_features'].sort.uniq.each do |f|
-  execute "enable_feature_#{f}" do
-    command "/usr/sbin/icinga2 feature enable #{f}"
-    creates ::File.join(node['icinga2']['features_enabled_dir'], "#{f}.conf")
-    only_if { node['icinga2']['enable_features_recipe'] && ::File.exist?(::File.join(node['icinga2']['features_available_dir'], "#{f}.conf")) }
-    notifies :reload, 'service[icinga2]', :delayed
-  end
+  icinga2_feature f
 end
 
 # disable all featues not defined to enable
 (node['icinga2']['features'].sort.uniq - node['icinga2']['enable_features'].sort.uniq).each do |f|
-  execute "disable_feature_#{f}" do
-    command "/usr/sbin/icinga2 feature disable #{f}"
-    only_if { node['icinga2']['enable_features_recipe'] && ::File.exist?(::File.join(node['icinga2']['features_enabled_dir'], "#{f}.conf")) }
-    notifies :reload, 'service[icinga2]', :delayed
+  icinga2_feature f do
+    enable false
   end
 end


### PR DESCRIPTION
some times we need to customize templates for icinga2 features like ido-mysql, api, etc. This patch allow to deploy template source from custom cookbook and customize feature list.