### PR TITLE
fix failover_timeout erroro

### DIFF
--- a/resources/idomysqlconnection.rb
+++ b/resources/idomysqlconnection.rb
@@ -31,6 +31,6 @@ attribute :table_prefix,  :kind_of => String, :default => 'icinga_'
 attribute :instance_name,  :kind_of => String, :default => 'default'
 attribute :instance_description,  :kind_of => String, :default => nil
 attribute :enable_ha,  :kind_of => [TrueClass, FalseClass], :default => nil
-attribute :failover_timeout,  :kind_of => [String, Integer], :default => '60s'
+attribute :failover_timeout,  :kind_of => [String, Integer], :default => '60'
 attribute :cleanup,  :kind_of => Hash, :default => nil
 attribute :categories,  :kind_of => Array, :default => nil

--- a/resources/idopgsqlconnection.rb
+++ b/resources/idopgsqlconnection.rb
@@ -31,6 +31,6 @@ attribute :table_prefix,  :kind_of => String, :default => 'icinga_'
 attribute :instance_name,  :kind_of => String, :default => 'default'
 attribute :instance_description,  :kind_of => String, :default => nil
 attribute :enable_ha,  :kind_of => [TrueClass, FalseClass], :default => nil
-attribute :failover_timeout,  :kind_of => [String, Integer], :default => '60s'
+attribute :failover_timeout,  :kind_of => [String, Integer], :default => '60'
 attribute :cleanup,  :kind_of => Hash, :default => nil
 attribute :categories,  :kind_of => Array, :default => nil


### PR DESCRIPTION
fix error:
```
critical/config: Location:
/etc/icinga2/objects.d/idomysqlconnection.conf(18):   table_prefix = "icinga_"
/etc/icinga2/objects.d/idomysqlconnection.conf(19):   instance_name = "default"
/etc/icinga2/objects.d/idomysqlconnection.conf(20):   failover_timeout = "60s"
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^
/etc/icinga2/objects.d/idomysqlconnection.conf(21): }
/etc/icinga2/objects.d/idomysqlconnection.conf(22):

Config error: Error while evaluating expression: Attribute 'failover_timeout' cannot be set to value of type 'String'
critical/config: 1 errors, 0 warnings.
```