### PR TITLE
add attribute for disabling repository.d

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,7 @@ default['icinga2']['pnp'] = false
 
 # avoid conflicts
 default['icinga2']['disable_conf_d'] = false
+default['icinga2']['disable_repository_d'] = false
 default['icinga2']['add_cloud_custom_vars'] = true
 
 # itl defaults

--- a/templates/default/icinga2.conf.erb
+++ b/templates/default/icinga2.conf.erb
@@ -48,7 +48,11 @@ include "features-enabled/*.conf"
  * The repository.d directory contains all configuration objects
  * managed by the 'icinga2 repository' CLI commands.
  */
+<% if node['icinga2']['disable_repository_d'] -%>
+// include_recursive "repository.d"
+<% else -%>
 include_recursive "repository.d"
+<% end -%>
 
 /**
  * Although in theory you could define all your objects in this file


### PR DESCRIPTION
include repository.d is not used for the many types of icinga2 installations, ex: cluster with separate satellites, one server installations, etc. This PR allow for disabling repository.d. Disabling of unnecessary catalogs will simplify icinga2.conf and debugging problems.