### PR TITLE
allow to disable user_defined_objects_dir

### DIFF
--- a/recipes/server_core.rb
+++ b/recipes/server_core.rb
@@ -23,12 +23,19 @@
  node['icinga2']['scripts_dir'],
  node['icinga2']['zones_dir'],
  node['icinga2']['objects_dir'],
- node['icinga2']['user_defined_objects_dir'],
  node['icinga2']['features_enabled_dir'],
  node['icinga2']['features_available_dir'],
  node['icinga2']['custom_plugins_dir']
 ].each do |d|
   directory d do
+    owner node['icinga2']['user']
+    group node['icinga2']['group']
+    mode 0750
+  end
+end
+
+if node['icinga2']['user_defined_objects_dir']
+  directory node['icinga2']['user_defined_objects_dir'] do
     owner node['icinga2']['user']
     group node['icinga2']['group']
     mode 0750

--- a/templates/default/icinga2.conf.erb
+++ b/templates/default/icinga2.conf.erb
@@ -68,6 +68,7 @@ include_recursive "conf.d"
 // All Objects definitions conf files are stored under "objects.d/"
 include_recursive "<%= node['icinga2']['objects_d'] -%>"
 
+<% if node['icinga2']['user_defined_objects_d'] -%>
 // User defined Objects / Configuration
 include_recursive "<%= node['icinga2']['user_defined_objects_d'] -%>"
-
+<% end -%>


### PR DESCRIPTION
this PR allow to disable creation dir 'user_defined_objects_dir' and include in icinga2.conf. This allows for more fine-tune the configuration file.