### PR TITLE
Version constrain bug for centos newer than 7.0

### DIFF
--- a/attributes/server_apache.rb
+++ b/attributes/server_apache.rb
@@ -1,6 +1,6 @@
 
 default['icinga2']['apache_modules'] = value_for_platform(
-  %w(centos redhat fedora) => { '7' => %w(default mod_wsgi mod_php5 mod_cgi mod_ssl mod_rewrite),
+  %w(centos redhat fedora) => { '>= 7' => %w(default mod_wsgi mod_php5 mod_cgi mod_ssl mod_rewrite),
                                 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) },
   'amazon' => { 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) },
   'ubuntu' => { 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) }


### PR DESCRIPTION
Let's use a greater-than operator. This will only work with Chef-Client 12! I noticed this in the release notes of chef-client 12.

"value_for_platform method in the Recipe DSL supports version constraints Version constraints—>, <, >=, <=, ~>—may be used when specifying a version. An exception is raised if two version constraints match. An exact match will always take precedence over a match made from a version constraint."