### PR TITLE
Fix version contraint for centos 7 apache modules

### DIFF
--- a/attributes/server_apache.rb
+++ b/attributes/server_apache.rb
@@ -1,6 +1,6 @@
 
 default['icinga2']['apache_modules'] = value_for_platform(
-  %w(centos redhat fedora) => { '>= 7' => %w(default mod_wsgi mod_php5 mod_cgi mod_ssl mod_rewrite),
+  %w(centos redhat fedora) => { '>= 7.0' => %w(default mod_wsgi mod_php5 mod_cgi mod_ssl mod_rewrite),
                                 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) },
   'amazon' => { 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) },
   'ubuntu' => { 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) }


### PR DESCRIPTION
Same bug as in pull #24. Chef seems to be buggy here, but thats easy to check:

```bash
[vagrant@default-centos-70 ~]$ chef-apply -e "log value_for_platform(%w(centos redhat fedora) => { '>= 7.0' => %w(7),'default' => %w(default) })"
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * log[7] action write
[vagrant@default-centos-70 ~]$ chef-apply -e "log value_for_platform(%w(centos redhat fedora) => { '>= 7' => %w(7),'default' => %w(default) })"
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * log[default] action write
[vagrant@default-centos-70 ~]$ chef-apply -e "log value_for_platform(%w(centos redhat fedora) => { '>= 6.0' => %w(7),'default' => %w(default) })"
Recipe: (chef-apply cookbook)::(chef-apply recipe)
  * log[7] action write
```