### PR TITLE
Add quotes around commands

### DIFF
--- a/templates/default/object.checkcommand.conf.erb
+++ b/templates/default/object.checkcommand.conf.erb
@@ -14,11 +14,11 @@ object CheckCommand <%= object.inspect -%> {
   <% end -%>
   <% if options['command'] -%>
   <% if options['command'].is_a?(String) -%>
-  command = <%= options['command'] %>
+  command = "<%= options['command'] %>"
   <% elsif !options['command'].empty? -%>
   command = [
   <% options['command'].each do |cmd| -%>
-    <%= cmd  %>
+    "<%= cmd  %>"
   <% end -%>
   ]
   <% end -%>

--- a/templates/default/object.environment.conf.erb
+++ b/templates/default/object.environment.conf.erb
@@ -12,7 +12,9 @@ object Host <%= node_hash['fqdn'].inspect %> {
   <%- if @import -%>
   import <%= @import.inspect %>
   <%- end -%>
-  <%- if node_hash['hostname'] -%>
+  <%- if node_hash['fqdn'] -%>
+  display_name = <%= node_hash['fqdn'].inspect %>
+  <%- elsif node_hash['hostname'] -%>
   display_name = <%= node_hash['hostname'].inspect %>
   <%- end -%>
   <%- if node_hash['address'] -%>


### PR DESCRIPTION
icinga fails to restart as command is not quoted:
critical/config: Error: syntax error, unexpected / (T_DIVIDE_OP)
Location:
/etc/icinga2/objects.d/checkcommand.conf(10): object CheckCommand "px_elasticache_health_check_cpu" {
/etc/icinga2/objects.d/checkcommand.conf(11):   import "plugin-check-command"
/etc/icinga2/objects.d/checkcommand.conf(12):   command = /usr/lib64/nagios/plugins/check_elasticache.py --region $region$              -i $elasticache_host$ -m cpu             -c 98,95,90              -w 90,85,80
                                                          ^
/etc/icinga2/objects.d/checkcommand.conf(13):
/etc/icinga2/objects.d/checkcommand.conf(14): }
