### PR TITLE
Add set attribute to support 'apply Service for'

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,12 +839,28 @@ LWRP `service` creates an icinga `Service` object or template.
 
 Above LWRP resource will apply an icinga `Service` object to all `Hosts` with custom vars `host.vars.nrpe`.
 
+**LWRP Apply Service For Object example**
+
+	icinga2_applyservice 'areca' do
+    set 'areca => config in host.vars.areca'
+	  display_name '"areca raidset" + areca'
+	  import 'generic-service'
+	  check_command 'check_snmp'
+	  assign_where ['"areca" in host.vars.enabled_services']
+	  check_interval '5m'
+	  retry_interval '3m'
+	  max_check_attempts 2
+	end
+
+Above LWRP resource will apply an icinga `Service` object with a Service for set (also called hash or dictionary) to all `Hosts` with custom vars `host.vars.enabled_services` including 'areca'.
+
 
 **LWRP Options**
 
 
 - *action* (optional)	- default :create, options: :create, :delete, :reload
 - *display_name* (optional, String)	- icinga `Service` object attribute `display_name`
+- *set* (optional, String) - gives a set (hash/dictionary) to the icinga `service` object
 - *import* (optional, String)	- icinga `Service` object attribute `import`
 - *host_name* (optional, String)	- icinga `Service` object attribute `host_name`
 - *groups* (optional, Array)	- icinga `Service` object attribute `groups`

--- a/providers/applyservice.rb
+++ b/providers/applyservice.rb
@@ -72,6 +72,7 @@ def object_template
                                        'icon_image_alt' => resource.send('icon_image_alt'),
                                        'assign_where' => resource.send('assign_where'),
                                        'ignore_where' => resource.send('ignore_where'),
+                                       'set' => resource.send('set'),
                                        'custom_vars' => resource.send('custom_vars') }
   end
 

--- a/resources/applyservice.rb
+++ b/resources/applyservice.rb
@@ -49,3 +49,4 @@ attribute :icon_image_alt,  :kind_of => String, :default => nil
 attribute :custom_vars,     :kind_of => Hash, :default => nil
 attribute :assign_where,          :kind_of => Array, :default => nil
 attribute :ignore_where,          :kind_of => Array, :default => nil
+attribute :set,          :kind_of => String, :regex => /^[a-z]+\s=>\s[a-z]+\sin\s\S+$/, default: nil

--- a/templates/default/object.applyservice.conf.erb
+++ b/templates/default/object.applyservice.conf.erb
@@ -8,7 +8,7 @@
 */
 
 <% @objects.sort.map do |object, options|%>
-apply Service <%= object.inspect -%> {
+apply Service <%= options['set'].nil? ? object.inspect : "for (#{options['set']})" -%> {
   <%- if options['import'] -%>
   import <%= options['import'].inspect %>
   <%- end -%>


### PR DESCRIPTION
Closes [9366](https://dev.icinga.org/issues/9366).

Adds the ability to write an 'apply Service for'.

The way it works, is setting a 'set' attribute, to give in a set with your applyService:

```
icinga2_applyservice 'areca' do
  set 'areca => config in host.vars.areca'
  ...
end
```

This would result in an applyService config looking like this:

```
apply Service for (areca => config in host.vars.areca) {
  ...
}
```

The 'set' attribute expects a regex in the format of `/^[a-z]+\s=>\s[a-z]+\sin\s\S+$/`.