### PR TITLE
Adds evaluate_quotes method in favor of inspect

### DIFF
--- a/libraries/icinga2.rb
+++ b/libraries/icinga2.rb
@@ -1,0 +1,8 @@
+def evaluate_quotes(value)
+  return value unless value.is_a? String
+  if value.to_s.match(/\+/)
+    value
+  else
+    value.inspect
+  end
+end

--- a/templates/default/object.applyservice.conf.erb
+++ b/templates/default/object.applyservice.conf.erb
@@ -13,7 +13,7 @@ apply Service <%= object.inspect -%> {
   import <%= options['import'].inspect %>
   <%- end -%>
   <%- if options['display_name'] -%>
-  display_name = <%= options['display_name'].inspect %>
+  display_name = <%= evaluate_quotes(options['display_name']) %>
   <%- end -%>
   <%- if options['host_name'] -%>
   host_name = <%= options['host_name'].inspect %>
@@ -99,19 +99,19 @@ apply Service <%= object.inspect -%> {
   <% if var && value && value.is_a?(Hash) -%>
   <% value.each do |a, v|-%>
   <% if a && v && v.is_a?(Hash) && !v.empty?-%>
-  vars.<%= var -%><%= [a].inspect -%> = {
+  vars.<%= var -%><%= evaluate_quotes([a]) -%> = {
   <% v.each do |a1, v1|%>
   <% if a1 && v1 %>
-  <%= a1 -%> = <%= v1.inspect %>
+  <%= a1 -%> = <%= evaluate_quotes(v1) %>
   <% end -%>
   <% end -%>
   }
   <% else -%>
-  vars.<%= var -%><%= [a].inspect -%> = <%= v.inspect %>
+  vars.<%= var -%><%= evaluate_quotes([a]) -%> = <%= evaluate_quotes(v) %>
   <% end -%>
   <% end -%>
   <% elsif var && value -%>
-  vars.<%= var -%> = <%= value.inspect %>
+  vars.<%= var -%> = <%= evaluate_quotes(value) %>
   <% end -%>
   <% end -%>
   <% end -%>


### PR DESCRIPTION
Closes [9367](https://dev.icinga.org/issues/9367).

Adds a method that will not inspect a string if it contains a `+` sign. A `+` sign implies string concatenation and concatenation will not work if the var gets an inspected.