### PR TITLE
Node name added as a option for host display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ Above LWRP resource will create `Host` objects for a chef environment nodes for 
 - *enable_cluster_hostgroup* (optional, TrueClass/FalseClass)	- whether to create `HostGroup` objects for chef node cluster's
 - *enable_application_hostgroup* (optional, TrueClass/FalseClass)	- whether to create `HostGroup` objects for chef node application's
 - *enable_role_hostgroup* (optional, TrueClass/FalseClass)	- whether to create `HostGroup` objects for chef node run_list role
-- *host_display_name_attr* (optional, String)	- whether to use `hostname` or `fqdn` for Host Object attribute `display_name`, options: hostname fqdn
+- *host_display_name_attr* (optional, String)	- whether to use `hostname` or `fqdn` or `name` (chef node name) for Host Object attribute `display_name`, options: hostname fqdn name
 - *use_fqdn_resolv* (optional, TrueClass/FalseClass)	- whether to use DNS FQDN resolved address for `Host` object attribute `address`
 - *failover_fqdn_address* (optional, TrueClass/FalseClass)	- whether to use chef node attribute `node['ipaddress']` if failed to resolve node FQDN
 - *ignore_resolv_error* (optional, TrueClass/FalseClass)	- whether to ignore node FQDN resolve error
@@ -1810,7 +1810,7 @@ Above LWRP resource will apply `Dependency` to all `Host` objects for provided `
 
 * `default['icinga2']['limit_region']` (default: `true`): whether to limit monitoring to icinga2 server region, e.g. for ec2 collect nodes belongs to same region
 
-* `default['icinga2']['host_display_name_attr']` (default: `hostname`): whether to use `hostname` or `fqdn` for environment resource Host Object attribute `display_name`, options: hostname fqdn
+* `default['icinga2']['host_display_name_attr']` (default: `hostname`): whether to use `hostname` or `fqdn` or `name` (chef node name) for environment resource Host Object attribute `display_name`, options: hostname fqdn
 
 * `default['icinga2']['use_fqdn_resolv']` (default: `false`): whether to determine node `address` from fqdn
 

--- a/resources/environment.rb
+++ b/resources/environment.rb
@@ -43,7 +43,7 @@ attribute :exclude_roles,       :kind_of => Array, :default => []
 attribute :env_custom_vars,     :kind_of => Hash, :default => {}
 attribute :limit_region,        :kind_of => [TrueClass, FalseClass], :default => node['icinga2']['limit_region']
 attribute :server_region,       :kind_of => String, :default => nil
-attribute :host_display_name_attr,        :kind_of => String, :equal_to => %w(fqdn hostname), :default => node['icinga2']['host_display_name_attr']
+attribute :host_display_name_attr,        :kind_of => String, :equal_to => %w(fqdn hostname name), :default => node['icinga2']['host_display_name_attr']
 
 attribute :add_cloud_custom_vars,         :kind_of => [TrueClass, FalseClass], :default => node['icinga2']['add_cloud_custom_vars']
 attribute :env_filter_node_vars,          :kind_of => Hash, :default => {}


### PR DESCRIPTION
The host_display_name_attr is restricted to only fqdn and hostname
attributes of a node, only these could be used to name a host in icinga2.
This commit adds another option - a node name, under which is a node
registered within chef server.
For me this is useful, because nor fqdn or hostname are not really
descriptive and can't/won't change it. But I can use the chef node name,
which is under my control, nice and descriptive.