### PR TITLE
added suport for placing configuration into zones in zones.d

### DIFF
--- a/libraries/icinga2.rb
+++ b/libraries/icinga2.rb
@@ -18,3 +18,129 @@ def icinga2_resource_create?(a)
     false
   end
 end
+
+# the template icinga definition should be placed to a separate file with '_template' suffix in the filename
+# in order to do that for objects assigned to a zone, this function separate the object into two hashes
+def separateZoneResources(zone_objects)
+  objectResources = Hash.new
+  templateResources = Hash.new
+
+  zone_objects.each do |resourceKey, resourceObject|
+    if resourceObject['object_class'] == 'object'
+      objectResources[resourceKey] = resourceObject
+    elsif resourceObject['object_class'] == 'template'
+      templateResources[resourceKey] = resourceObject
+    else
+      Chef::Application.fatal!("Unknown object_class (#{resourceObject['object_class']}), resourceKey=#{resourceKey}, resourceObject=#{resourceObject}", 1) 
+    end
+  end
+
+  [objectResources, templateResources]
+end
+
+
+def processIcinga2Resources(resource_name, resource_keys, object_resources, template_support)
+  icinga2_objects = {}
+  # default value for a new key in the hash is an empty hash
+  # key is a zone name, the hash for the key keeps an objet definitions, each unique, each is a hash again
+  icinga2_zoned_objects = Hash.new { |h, k| h[k] = {} }
+
+  object_resources.reduce({}) do |_hash, resource|
+    next if !icinga2_resource_create?(resource.action) || icinga2_objects.key?(resource.name)
+    resource_data = Hash[resource_keys.map {|x| [x, resource.send(x)]}]
+
+    # not all icinga object support templating
+    # the object_class have to be determined in any case
+    if template_support
+      if resource.send('template')
+        resource_data['object_class'] = 'template'
+      else
+        resource_data['object_class'] = 'object'
+      end
+    else
+      resource_data['object_class'] = 'object'
+    end
+
+    # TODO check first is such an object/key exist already, print a warning if so
+    # if resource.send('template') && !icinga2_objects.key?(resource.name)
+    if resource_data['zone']
+      icinga2_zoned_objects[resource_data['zone']][resource.name] = resource_data
+    else
+      icinga2_objects[resource.name] = resource_data
+    end
+  end
+
+  # separate object and teplate icinga definitions
+  icinga2_objects_grouped = icinga2_objects.group_by { |k,v| v['object_class']}
+  # now, this might be better refactored into a simple function with a simple loop, because I don't think I'll be
+  # able to understand immediatelly after a halt year or so
+  # what is does, it just produces a hash, with two keys, 'object' and 'template', under a key is another hash with
+  # icinga object definitions, which are then processed by a template resource and ERB template file
+  icinga2_objects_dict = icinga2_objects_grouped.keys.each_with_object({'object' => {}, 'template' => {}}) { |str,hash| hash[str] = Hash[icinga2_objects_grouped[str]]}
+
+  ot = template ::File.join(node['icinga2']['objects_dir'], "#{resource_name}.conf") do
+    source "object.#{resource_name}.conf.erb"
+    cookbook 'icinga2'
+    owner node['icinga2']['user']
+    group node['icinga2']['group']
+    mode 0640
+    variables(:objects => icinga2_objects_dict['object'])
+    notifies :reload, 'service[icinga2]', :delayed
+    only_if { icinga2_objects_dict['object'].length > 0 }
+  end
+
+  te = template ::File.join(node['icinga2']['objects_dir'], "#{resource_name}_template.conf") do
+    source "object.#{resource_name}.conf.erb"
+    cookbook 'icinga2'
+    owner node['icinga2']['user']
+    group node['icinga2']['group']
+    mode 0640
+    variables(:objects => icinga2_objects_dict['template'])
+    notifies :reload, 'service[icinga2]', :delayed
+    only_if { icinga2_objects_dict['template'].length > 0 }
+  end
+
+  zoned_objects_updated = false
+
+  icinga2_zoned_objects.each do |zone, zone_objects|
+
+    directory ::File.join(node['icinga2']['zones_dir'], zone) do
+      owner node['icinga2']['user']
+      group node['icinga2']['group']
+      action :create
+      only_if { zone_objects.length > 0 }
+    end
+
+    zoned_objects, zoned_templates = separateZoneResources(zone_objects)
+
+    zoned_ot = template ::File.join(node['icinga2']['zones_dir'], zone, "#{resource_name}.conf") do
+      source "object.#{resource_name}.conf.erb"
+      cookbook 'icinga2'
+      owner node['icinga2']['user']
+      group node['icinga2']['group']
+      mode 0640
+      variables(:objects => zoned_objects)
+      notifies :reload, 'service[icinga2]', :delayed
+      only_if { zoned_objects.length > 0 }
+    end
+
+    zoned_te = template ::File.join(node['icinga2']['zones_dir'], zone, "#{resource_name}_template.conf") do
+      source "object.#{resource_name}.conf.erb"
+      cookbook 'icinga2'
+      owner node['icinga2']['user']
+      group node['icinga2']['group']
+      mode 0640
+      variables(:objects => zoned_templates)
+      notifies :reload, 'service[icinga2]', :delayed
+      only_if { zoned_templates.length > 0 }
+    end
+
+    if zoned_ot.updated? || zoned_te.updated?
+      zoned_objects_updated = true
+    end
+
+  end
+
+  ot.updated? || te.updated? || zoned_objects_updated
+
+end

--- a/providers/applynotification.rb
+++ b/providers/applynotification.rb
@@ -40,34 +40,7 @@ end
 
 # collect objects and create resource template
 def object_template
-  # collect objects
-  icinga2_objects = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next if !icinga2_resource_create?(resource.action) || icinga2_objects.key?(resource.name)
-    icinga2_objects[resource.name] = {}
-    icinga2_objects[resource.name] = { 'object_type' => resource.send('object_type'),
-                                       'import' => resource.send('import'),
-                                       'command' => resource.send('command'),
-                                       'users' => resource.send('users'),
-                                       'user_groups' => resource.send('user_groups'),
-                                       'interval' => resource.send('interval'),
-                                       'period' => resource.send('period'),
-                                       'types' => resource.send('types'),
-                                       'states' => resource.send('states'),
-                                       'times' => resource.send('times'),
-                                       'assign_where' => resource.send('assign_where'),
-                                       'ignore_where' => resource.send('ignore_where') }
-  end
+  resource_keys = %w(object_type import command users user_groups interval period types states times assign_where ignore_where zone)
 
-  # create object resource
-  ot = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => icinga2_objects)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ot.updated?
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, false)
 end

--- a/providers/applyservice.rb
+++ b/providers/applyservice.rb
@@ -40,51 +40,7 @@ end
 
 # collect objects and create resource template
 def object_template
-  # collect objects
-  icinga2_objects = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next if !icinga2_resource_create?(resource.action) || icinga2_objects.key?(resource.name)
-    icinga2_objects[resource.name] = {}
-    icinga2_objects[resource.name] = { 'import' => resource.send('import'),
-                                       'display_name' => resource.send('display_name'),
-                                       'host_name' => resource.send('host_name'),
-                                       'groups' => resource.send('groups'),
-                                       'check_command' => resource.send('check_command'),
-                                       'max_check_attempts' => resource.send('max_check_attempts'),
-                                       'check_period' => resource.send('check_period'),
-                                       'check_interval' => resource.send('check_interval'),
-                                       'retry_interval' => resource.send('retry_interval'),
-                                       'enable_notifications' => resource.send('enable_notifications'),
-                                       'enable_active_checks' => resource.send('enable_active_checks'),
-                                       'enable_passive_checks' => resource.send('enable_passive_checks'),
-                                       'enable_event_handler' => resource.send('enable_event_handler'),
-                                       'enable_flapping' => resource.send('enable_flapping'),
-                                       'enable_perfdata' => resource.send('enable_perfdata'),
-                                       'event_command' => resource.send('event_command'),
-                                       'flapping_threshold' => resource.send('flapping_threshold'),
-                                       'volatile' => resource.send('volatile'),
-                                       'zone' => resource.send('zone'),
-                                       'command_endpoint' => resource.send('command_endpoint'),
-                                       'notes' => resource.send('notes'),
-                                       'notes_url' => resource.send('notes_url'),
-                                       'action_url' => resource.send('action_url'),
-                                       'icon_image' => resource.send('icon_image'),
-                                       'icon_image_alt' => resource.send('icon_image_alt'),
-                                       'assign_where' => resource.send('assign_where'),
-                                       'ignore_where' => resource.send('ignore_where'),
-                                       'set' => resource.send('set'),
-                                       'custom_vars' => resource.send('custom_vars') }
-  end
+  resource_keys = %w(import display_name host_name groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt assign_where ignore_where set custom_vars)
 
-  # create object resource
-  ot = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => icinga2_objects)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ot.updated?
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, false)
 end

--- a/providers/checkcommand.rb
+++ b/providers/checkcommand.rb
@@ -38,59 +38,8 @@ def object_resources
   end
 end
 
-# collect objects and create resource template
-def objects
-  # collect objects
-  icinga2_objects = {}
-  icinga2_templates = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next unless icinga2_resource_create?(resource.action)
-    if resource.send('template') && !icinga2_templates.key?(resource.name)
-      icinga2_templates[resource.name] = {}
-      icinga2_templates[resource.name] = { 'import' => resource.send('import'),
-                                           'command' => resource.send('command'),
-                                           'env' => resource.send('env'),
-                                           'timeout' => resource.send('timeout'),
-                                           'zone' => resource.send('zone'),
-                                           'arguments' => resource.send('arguments'),
-                                           'custom_vars' => resource.send('custom_vars'),
-                                           'object_class' => 'template' }
-    elsif !icinga2_objects.key?(resource.name)
-      icinga2_objects[resource.name] = {}
-      icinga2_objects[resource.name] = { 'import' => resource.send('import'),
-                                         'command' => resource.send('command'),
-                                         'env' => resource.send('env'),
-                                         'timeout' => resource.send('timeout'),
-                                         'zone' => resource.send('zone'),
-                                         'arguments' => resource.send('arguments'),
-                                         'custom_vars' => resource.send('custom_vars'),
-                                         'object_class' => 'object' }
-    end
-  end
-  [icinga2_objects, icinga2_templates]
-end
-
-# create object / template resource
 def object_template
-  objs, tmpls = objects
-  # create object resource
-  ob = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => objs)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  te = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}_template.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => tmpls)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ob.updated? || te.updated?
+  resource_keys = %w(import command env timeout zone arguments custom_vars)
+
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, true)
 end

--- a/providers/environment.rb
+++ b/providers/environment.rb
@@ -68,7 +68,19 @@ def create_objects
   else
     env_hosts = {}
   end
-  hosts_template = template ::File.join(node['icinga2']['objects_dir'], template_file_name) do
+  if new_resource.zone
+    env_resources_path = ::File.join(node['icinga2']['zones_dir'], new_resource.zone, template_file_name)
+
+    directory ::File.join(node['icinga2']['zones_dir'], new_resource.zone) do
+      owner node['icinga2']['user']
+      group node['icinga2']['group']
+      action :create
+      only_if { env_hosts.length > 0 }
+    end
+  else
+    env_resources_path = ::File.join(node['icinga2']['objects_dir'], template_file_name)
+  end
+  hosts_template = template env_resources_path do
     source new_resource.template
     cookbook new_resource.cookbook
     owner node['icinga2']['user']
@@ -92,7 +104,6 @@ def create_objects
               :event_command => new_resource.event_command,
               :flapping_threshold => new_resource.flapping_threshold,
               :volatile => new_resource.volatile,
-              :zone => new_resource.zone,
               :command_endpoint => new_resource.command_endpoint,
               :notes => new_resource.notes,
               :notes_url => new_resource.notes_url,

--- a/providers/host.rb
+++ b/providers/host.rb
@@ -38,97 +38,10 @@ def object_resources
   end
 end
 
-# collect objects
-def objects
-  icinga2_objects = {}
-  icinga2_templates = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next unless icinga2_resource_create?(resource.action)
-    if resource.send('template') && !icinga2_templates.key?(resource.name)
-      icinga2_templates[resource.name] = {}
-      icinga2_templates[resource.name] = { 'import' => resource.send('import'),
-                                           'display_name' => resource.send('display_name'),
-                                           'address' => resource.send('address'),
-                                           'address6' => resource.send('address6'),
-                                           'groups' => resource.send('groups'),
-                                           'check_command' => resource.send('check_command'),
-                                           'max_check_attempts' => resource.send('max_check_attempts'),
-                                           'check_period' => resource.send('check_period'),
-                                           'check_interval' => resource.send('check_interval'),
-                                           'retry_interval' => resource.send('retry_interval'),
-                                           'enable_notifications' => resource.send('enable_notifications'),
-                                           'enable_active_checks' => resource.send('enable_active_checks'),
-                                           'enable_passive_checks' => resource.send('enable_passive_checks'),
-                                           'enable_event_handler' => resource.send('enable_event_handler'),
-                                           'enable_flapping' => resource.send('enable_flapping'),
-                                           'enable_perfdata' => resource.send('enable_perfdata'),
-                                           'event_command' => resource.send('event_command'),
-                                           'flapping_threshold' => resource.send('flapping_threshold'),
-                                           'volatile' => resource.send('volatile'),
-                                           'zone' => resource.send('zone'),
-                                           'command_endpoint' => resource.send('command_endpoint'),
-                                           'notes' => resource.send('notes'),
-                                           'notes_url' => resource.send('notes_url'),
-                                           'action_url' => resource.send('action_url'),
-                                           'icon_image' => resource.send('icon_image'),
-                                           'icon_image_alt' => resource.send('icon_image_alt'),
-                                           'custom_vars' => resource.send('custom_vars'),
-                                           'object_class' => 'template' }
-    elsif !icinga2_objects.key?(resource.name)
-      icinga2_objects[resource.name] = {}
-      icinga2_objects[resource.name] = { 'import' => resource.send('import'),
-                                         'display_name' => resource.send('display_name'),
-                                         'address' => resource.send('address'),
-                                         'address6' => resource.send('address6'),
-                                         'groups' => resource.send('groups'),
-                                         'check_command' => resource.send('check_command'),
-                                         'max_check_attempts' => resource.send('max_check_attempts'),
-                                         'check_period' => resource.send('check_period'),
-                                         'check_interval' => resource.send('check_interval'),
-                                         'retry_interval' => resource.send('retry_interval'),
-                                         'enable_notifications' => resource.send('enable_notifications'),
-                                         'enable_active_checks' => resource.send('enable_active_checks'),
-                                         'enable_passive_checks' => resource.send('enable_passive_checks'),
-                                         'enable_event_handler' => resource.send('enable_event_handler'),
-                                         'enable_flapping' => resource.send('enable_flapping'),
-                                         'enable_perfdata' => resource.send('enable_perfdata'),
-                                         'event_command' => resource.send('event_command'),
-                                         'flapping_threshold' => resource.send('flapping_threshold'),
-                                         'volatile' => resource.send('volatile'),
-                                         'zone' => resource.send('zone'),
-                                         'command_endpoint' => resource.send('command_endpoint'),
-                                         'notes' => resource.send('notes'),
-                                         'notes_url' => resource.send('notes_url'),
-                                         'action_url' => resource.send('action_url'),
-                                         'icon_image' => resource.send('icon_image'),
-                                         'icon_image_alt' => resource.send('icon_image_alt'),
-                                         'custom_vars' => resource.send('custom_vars'),
-                                         'object_class' => 'object' }
-    end
-  end
-  [icinga2_objects, icinga2_templates]
-end
 
 # create object resource
 def object_template
-  objs, tmpls = objects
-  ob = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => objs)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  te = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}_template.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => tmpls)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ob.updated? || te.updated?
+  resource_keys = %w(import display_name address address6 groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars)
+
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, true)
 end

--- a/providers/notification.rb
+++ b/providers/notification.rb
@@ -38,71 +38,10 @@ def object_resources
   end
 end
 
-# collect objects
-def objects
-  icinga2_objects = {}
-  icinga2_templates = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next unless icinga2_resource_create?(resource.action)
-    if resource.send('template') && !icinga2_templates.key?(resource.name)
-      icinga2_templates[resource.name] = {}
-      icinga2_templates[resource.name] = { 'import' => resource.send('import'),
-                                           'host_name' => resource.send('host_name'),
-                                           'service_name' => resource.send('service_name'),
-                                           'users' => resource.send('users'),
-                                           'user_groups' => resource.send('user_groups'),
-                                           'times' => resource.send('times'),
-                                           'command' => resource.send('command'),
-                                           'interval' => resource.send('interval'),
-                                           'period' => resource.send('period'),
-                                           'zone' => resource.send('zone'),
-                                           'types' => resource.send('types'),
-                                           'states' => resource.send('states'),
-                                           'object_class' => 'template',
-                                           'custom_vars' => resource.send('custom_vars')
-      }
-    elsif !icinga2_objects.key?(resource.name)
-      icinga2_objects[resource.name] = {}
-      icinga2_objects[resource.name] = { 'import' => resource.send('import'),
-                                         'host_name' => resource.send('host_name'),
-                                         'service_name' => resource.send('service_name'),
-                                         'users' => resource.send('users'),
-                                         'user_groups' => resource.send('user_groups'),
-                                         'times' => resource.send('times'),
-                                         'command' => resource.send('command'),
-                                         'interval' => resource.send('interval'),
-                                         'period' => resource.send('period'),
-                                         'zone' => resource.send('zone'),
-                                         'types' => resource.send('types'),
-                                         'states' => resource.send('states'),
-                                         'object_class' => 'object',
-                                         'custom_vars' => resource.send('custom_vars')
-      }
-    end
-  end
-  [icinga2_objects, icinga2_templates]
-end
 
 # create object resource
 def object_template
-  objs, tmpls = objects
-  ob = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => objs)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  te = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}_template.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => tmpls)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ob.updated? || te.updated?
+  resource_keys = %w(import host_name service_name users user_groups times command interval period zone types states custom_vars)
+
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, true)
 end

--- a/providers/notificationcommand.rb
+++ b/providers/notificationcommand.rb
@@ -38,60 +38,9 @@ def object_resources
   end
 end
 
-# collect objects and create resource template
-def objects
-  # collect objects
-  icinga2_objects = {}
-  icinga2_templates = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next unless icinga2_resource_create?(resource.action)
-    if resource.send('template') && !icinga2_templates.key?(resource.name)
-      icinga2_templates[resource.name] = {}
-      icinga2_templates[resource.name] = { 'import' => resource.send('import'),
-                                           'command' => resource.send('command'),
-                                           'env' => resource.send('env'),
-                                           'timeout' => resource.send('timeout'),
-                                           'zone' => resource.send('zone'),
-                                           'arguments' => resource.send('arguments'),
-                                           'custom_vars' => resource.send('custom_vars'),
-                                           'object_class' => 'template' }
-    elsif !icinga2_objects.key?(resource.name)
-      icinga2_objects[resource.name] = {}
-      icinga2_objects[resource.name] = { 'import' => resource.send('import'),
-                                         'command' => resource.send('command'),
-                                         'env' => resource.send('env'),
-                                         'timeout' => resource.send('timeout'),
-                                         'zone' => resource.send('zone'),
-                                         'arguments' => resource.send('arguments'),
-                                         'custom_vars' => resource.send('custom_vars'),
-                                         'object_class' => 'object' }
-    end
-  end
-  [icinga2_objects, icinga2_templates]
-end
-
 # create object / template resource
 def object_template
-  objs, tmpls = objects
-  # create object resource
-  ob = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => objs)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  # create template resource
-  te = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}_template.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => tmpls)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ob.updated? || te.updated?
+  resource_keys = %w(import command env timeout zone arguments custom_vars zone)
+
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, true)
 end

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -38,95 +38,9 @@ def object_resources
   end
 end
 
-# collect objects
-def objects
-  icinga2_objects = {}
-  icinga2_templates = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next unless icinga2_resource_create?(resource.action)
-    if resource.send('template') && !icinga2_templates.key?(resource.name)
-      icinga2_templates[resource.name] = {}
-      icinga2_templates[resource.name] = { 'import' => resource.send('import'),
-                                           'display_name' => resource.send('display_name'),
-                                           'host_name' => resource.send('host_name'),
-                                           'groups' => resource.send('groups'),
-                                           'check_command' => resource.send('check_command'),
-                                           'max_check_attempts' => resource.send('max_check_attempts'),
-                                           'check_period' => resource.send('check_period'),
-                                           'check_interval' => resource.send('check_interval'),
-                                           'retry_interval' => resource.send('retry_interval'),
-                                           'enable_notifications' => resource.send('enable_notifications'),
-                                           'enable_active_checks' => resource.send('enable_active_checks'),
-                                           'enable_passive_checks' => resource.send('enable_passive_checks'),
-                                           'enable_event_handler' => resource.send('enable_event_handler'),
-                                           'enable_flapping' => resource.send('enable_flapping'),
-                                           'enable_perfdata' => resource.send('enable_perfdata'),
-                                           'event_command' => resource.send('event_command'),
-                                           'flapping_threshold' => resource.send('flapping_threshold'),
-                                           'volatile' => resource.send('volatile'),
-                                           'zone' => resource.send('zone'),
-                                           'command_endpoint' => resource.send('command_endpoint'),
-                                           'notes' => resource.send('notes'),
-                                           'notes_url' => resource.send('notes_url'),
-                                           'action_url' => resource.send('action_url'),
-                                           'icon_image' => resource.send('icon_image'),
-                                           'icon_image_alt' => resource.send('icon_image_alt'),
-                                           'custom_vars' => resource.send('custom_vars'),
-                                           'object_class' => 'template' }
-    elsif !icinga2_objects.key?(resource.name)
-      icinga2_objects[resource.name] = {}
-      icinga2_objects[resource.name] = { 'import' => resource.send('import'),
-                                         'display_name' => resource.send('display_name'),
-                                         'host_name' => resource.send('host_name'),
-                                         'groups' => resource.send('groups'),
-                                         'check_command' => resource.send('check_command'),
-                                         'max_check_attempts' => resource.send('max_check_attempts'),
-                                         'check_period' => resource.send('check_period'),
-                                         'check_interval' => resource.send('check_interval'),
-                                         'retry_interval' => resource.send('retry_interval'),
-                                         'enable_notifications' => resource.send('enable_notifications'),
-                                         'enable_active_checks' => resource.send('enable_active_checks'),
-                                         'enable_passive_checks' => resource.send('enable_passive_checks'),
-                                         'enable_event_handler' => resource.send('enable_event_handler'),
-                                         'enable_flapping' => resource.send('enable_flapping'),
-                                         'enable_perfdata' => resource.send('enable_perfdata'),
-                                         'event_command' => resource.send('event_command'),
-                                         'flapping_threshold' => resource.send('flapping_threshold'),
-                                         'volatile' => resource.send('volatile'),
-                                         'zone' => resource.send('zone'),
-                                         'command_endpoint' => resource.send('command_endpoint'),
-                                         'notes' => resource.send('notes'),
-                                         'notes_url' => resource.send('notes_url'),
-                                         'action_url' => resource.send('action_url'),
-                                         'icon_image' => resource.send('icon_image'),
-                                         'icon_image_alt' => resource.send('icon_image_alt'),
-                                         'custom_vars' => resource.send('custom_vars'),
-                                         'object_class' => 'object' }
-    end
-  end
-  [icinga2_objects, icinga2_templates]
-end
-
 # create object resource
 def object_template
-  objs, tmpls = objects
-  ob = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => objs)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  te = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}_template.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => tmpls)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ob.updated? || te.updated?
+  resource_keys = %w(import display_name host_name groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars)
+
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, true)
 end

--- a/providers/timeperiod.rb
+++ b/providers/timeperiod.rb
@@ -38,51 +38,9 @@ def object_resources
   end
 end
 
-# collect objects
-def objects
-  icinga2_objects = {}
-  icinga2_templates = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next unless icinga2_resource_create?(resource.action)
-    if resource.send('template') && !icinga2_templates.key?(resource.name)
-      icinga2_templates[resource.name] = {}
-      icinga2_templates[resource.name] = { 'display_name' => resource.send('display_name'),
-                                           'zone' => resource.send('zone'),
-                                           'ranges' => resource.send('ranges'),
-                                           'object_class' => 'template',
-                                           'import' => resource.send('import') }
-    elsif !icinga2_objects.key?(resource.name)
-      icinga2_objects[resource.name] = {}
-      icinga2_objects[resource.name] = { 'display_name' => resource.send('display_name'),
-                                         'zone' => resource.send('zone'),
-                                         'ranges' => resource.send('ranges'),
-                                         'object_class' => 'object',
-                                         'import' => resource.send('import') }
-    end
-  end
-  [icinga2_objects, icinga2_templates]
-end
-
 # create object resource
 def object_template
-  objs, tmpls = objects
-  ob = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => objs)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  te = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}_template.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => tmpls)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ob.updated? || te.updated?
+  resource_keys = %w(display_name ranges zone import)
+
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, true)
 end

--- a/providers/usergroup.rb
+++ b/providers/usergroup.rb
@@ -40,25 +40,7 @@ end
 
 # collect objects and create resource template
 def object_template
-  # collect objects
-  icinga2_objects = {}
-  object_resources.reduce({}) do |_hash, resource|
-    next if !icinga2_resource_create?(resource.action) || icinga2_objects.key?(resource.name)
-    icinga2_objects[resource.name] = {}
-    icinga2_objects[resource.name] = { 'display_name' => resource.send('display_name'),
-                                       'zone' => resource.send('zone'),
-                                       'groups' => resource.send('groups') }
-  end
+  resource_keys = %w(display_name groups zone)
 
-  # create object resource
-  ot = template ::File.join(node['icinga2']['objects_dir'], "#{::File.basename(__FILE__, '.rb')}.conf") do
-    source "object.#{::File.basename(__FILE__, '.rb')}.conf.erb"
-    cookbook 'icinga2'
-    owner node['icinga2']['user']
-    group node['icinga2']['group']
-    mode 0640
-    variables(:objects => icinga2_objects)
-    notifies :reload, 'service[icinga2]', :delayed
-  end
-  ot.updated?
+  processIcinga2Resources(::File.basename(__FILE__, '.rb'), resource_keys, object_resources, false)
 end

--- a/resources/applynotification.rb
+++ b/resources/applynotification.rb
@@ -33,3 +33,4 @@ attribute :states,        :kind_of => Array, :default => nil
 attribute :times,         :kind_of => Hash, :default => nil
 attribute :assign_where,          :kind_of => Array, :default => nil
 attribute :ignore_where,          :kind_of => Array, :default => nil
+attribute :zone,          :kind_of => String, :default => nil

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -29,7 +29,7 @@ attribute :pager,         :kind_of => String, :default => nil
 attribute :period,        :kind_of => String, :default => nil
 attribute :states,        :kind_of => Array, :default => nil
 attribute :types,         :kind_of => Array, :default => nil
-attribute :zone,          :kind_of => Array, :default => nil
+attribute :zone,          :kind_of => String, :default => nil
 attribute :custom_vars,   :kind_of => Hash, :default => nil
 attribute :enable_notifications,   :kind_of => [TrueClass, FalseClass, NilClass], :default => nil
 attribute :template,      :kind_of => [TrueClass, FalseClass, NilClass], :default => nil

--- a/templates/default/object.applyservice.conf.erb
+++ b/templates/default/object.applyservice.conf.erb
@@ -63,9 +63,6 @@ apply Service <%= options['set'].nil? ? object.inspect : "for (#{options['set']}
   <%- unless options['volatile'].nil? -%>
   volatile = <%= options['volatile'].inspect %>
   <%- end -%>
-  <%- if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <%- end -%>
   <%- if options['command_endpoint'] -%>
   command_endpoint = <%= options['command_endpoint'].inspect %>
   <%- end -%>

--- a/templates/default/object.checkcommand.conf.erb
+++ b/templates/default/object.checkcommand.conf.erb
@@ -51,9 +51,6 @@
   }
   <% end -%>
 
-  <% if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <% end -%>
   <% if options['custom_vars'] -%>
   <% Hash[options['custom_vars'].sort].each do |var, value| -%>
   <% if var && value -%>

--- a/templates/default/object.environment.conf.erb
+++ b/templates/default/object.environment.conf.erb
@@ -66,9 +66,6 @@ object Host <%= node_hash['fqdn'].inspect %> {
   <%- unless @volatile.nil? -%>
   volatile = <%= @volatile.inspect %>
   <%- end -%>
-  <%- if @zone -%>
-  zone = <%= @zone.inspect %>
-  <%- end -%>
   <%- if @command_endpoint -%>
   command_endpoint = <%= @command_endpoint.inspect %>
   <%- end -%>

--- a/templates/default/object.host.conf.erb
+++ b/templates/default/object.host.conf.erb
@@ -66,9 +66,6 @@
   <%- unless options['volatile'].nil? -%>
   volatile = <%= options['volatile'].inspect %>
   <%- end -%>
-  <%- if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <%- end -%>
   <%- if options['command_endpoint'] -%>
   command_endpoint = <%= options['command_endpoint'].inspect %>
   <%- end -%>

--- a/templates/default/object.notificationcommand.conf.erb
+++ b/templates/default/object.notificationcommand.conf.erb
@@ -51,9 +51,6 @@
   }
   <% end -%>
 
-  <% if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <% end -%>
   <% if options['custom_vars'] -%>
   <% Hash[options['custom_vars'].sort].each do |var, value| -%>
   <% if var && value -%>

--- a/templates/default/object.service.conf.erb
+++ b/templates/default/object.service.conf.erb
@@ -63,9 +63,6 @@
   <%- unless options['volatile'].nil? -%>
   volatile = <%= options['volatile'].inspect %>
   <%- end -%>
-  <%- if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <%- end -%>
   <%- if options['command_endpoint'] -%>
   command_endpoint = <%= options['command_endpoint'].inspect %>
   <%- end -%>

--- a/templates/default/object.timeperiod.conf.erb
+++ b/templates/default/object.timeperiod.conf.erb
@@ -15,9 +15,6 @@
   <% if options['display_name'] -%>
   display_name = <%= options['display_name'].inspect %>
   <% end -%>
-  <% if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <% end -%>
   <% if options['ranges'] -%>
   ranges = {
   <% options['ranges'].each do |day, time| -%>

--- a/templates/default/object.user.conf.erb
+++ b/templates/default/object.user.conf.erb
@@ -24,9 +24,6 @@
   <% if options['email'] -%>
   email = <%= options['email'].inspect %>
   <% end -%>
-  <% if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <% end -%>
   <% if options['pager'] -%>
   pager = <%= options['pager'].inspect %>
   <% end -%>

--- a/templates/default/object.usergroup.conf.erb
+++ b/templates/default/object.usergroup.conf.erb
@@ -15,9 +15,6 @@ object UserGroup <%= object.inspect -%> {
   <% if options['groups'] && !options['groups'].empty? -%>
   groups = <%= options['groups'].sort.uniq.inspect %>
   <% end -%>
-  <% if options['zone'] -%>
-  zone = <%= options['zone'].inspect %>
-  <% end -%>
 }
 
 <% end -%>


### PR DESCRIPTION
Hello,
I'm using chef and chef-icinga2 cookbook to generate the configuration for our monitoring. It's great, it works very good, thanks for all your work!
We have a single master (HA will come soon), a few satellite icinga instances and plenty of remote clients, the whole cluster will grow over a time.

I like the idea of configuration sync in Icinga2, by putting the configuration files into zones.d/zone_name/.
Unfortunatelly, this was not possible with the chef-icinga2 cookbook, so I tried to add support for it.

You just have to set the "zone" attribute of a LWRP to the zone name and then the configuration is placed into a config file in zones.d/zone_name/, instead of objects.d.
The "zone" attribute has been removed from the LWRP templates, as it doesn't do anything (https://lists.icinga.org/pipermail/icinga-users/2015-August/009948.html).

Right now, not all the LWRPs were modified in order to add the zoning support, just these I was using at the time. 
I can finish it, if this feature is accepted as useful.
The code itself needs a refactoring maybe, it could be better.

https://dev.icinga.org/issues/10094