### PR TITLE
Added an option to put the default icinga object into the global zone

### DIFF
--- a/attributes/server_objects.rb
+++ b/attributes/server_objects.rb
@@ -1,4 +1,5 @@
 
+default['icinga2']['server']['object']['global-templates'] = false
 default['icinga2']['server']['object']['host']['import'] = 'generic-host'
 default['icinga2']['server']['object']['host']['max_check_attempts'] = 3
 default['icinga2']['server']['object']['host']['check_period'] = nil

--- a/recipes/server_object_host.rb
+++ b/recipes/server_object_host.rb
@@ -23,4 +23,5 @@ icinga2_host 'generic-host' do
   check_interval node['icinga2']['server']['object']['host']['check_interval']
   retry_interval node['icinga2']['server']['object']['host']['retry_interval']
   check_command node['icinga2']['server']['object']['host']['check_command']
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end

--- a/recipes/server_object_notificationcommand.rb
+++ b/recipes/server_object_notificationcommand.rb
@@ -31,6 +31,7 @@ icinga2_notificationcommand 'mail-service-notification' do
       'HOSTDISPLAYNAME' => '$host.display_name$',\
       'SERVICEDISPLAYNAME' => '$service.display_name$',\
       'USEREMAIL' => '$user.email$'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end
 
 # add icinga host notification command
@@ -47,4 +48,5 @@ icinga2_notificationcommand 'mail-host-notification' do
       'USEREMAIL' => '$user.email$',\
       'HOSTSTATE' => '$host.state$',\
       'HOSTOUTPUT' => '$host.output$'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end

--- a/recipes/server_object_service.rb
+++ b/recipes/server_object_service.rb
@@ -22,4 +22,5 @@ icinga2_service 'generic-service' do
   max_check_attempts node['icinga2']['server']['object']['host']['max_check_attempts']
   check_interval node['icinga2']['server']['object']['host']['check_interval']
   retry_interval node['icinga2']['server']['object']['host']['retry_interval']
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end

--- a/recipes/server_object_timeperiod.rb
+++ b/recipes/server_object_timeperiod.rb
@@ -27,6 +27,7 @@ icinga2_timeperiod '24x7' do
          'friday' => '00:00-24:00',
          'saturday' => '00:00-24:00',
          'sunday' => '00:00-24:00'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end
 
 icinga2_timeperiod '9to5' do
@@ -37,9 +38,11 @@ icinga2_timeperiod '9to5' do
          'wednesday' => '09:00-17:00',
          'thursday'  => '09:00-17:00',
          'friday' => '09:00-17:00'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end
 
 icinga2_timeperiod 'never' do
   import 'legacy-timeperiod'
   display_name 'Icinga 2 never TimePeriod'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end

--- a/recipes/server_object_user.rb
+++ b/recipes/server_object_user.rb
@@ -20,6 +20,7 @@
 # generic-user user template
 icinga2_user 'generic-user' do
   template true
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end
 
 # add default icingaadmin user
@@ -31,4 +32,5 @@ icinga2_user 'icingaadmin' do
   display_name 'Icinga 2 Admin'
   groups %w(icingaadmins)
   email 'root@localhost'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end

--- a/recipes/server_object_usergroup.rb
+++ b/recipes/server_object_usergroup.rb
@@ -19,4 +19,5 @@
 
 icinga2_usergroup 'icingaadmins' do
   display_name 'Icinga 2 Admin Group'
+  zone node['icinga2']['server']['object']['global-templates'] ? 'global-templates' : nil
 end


### PR DESCRIPTION
One more addition to the zone sync feature, I think one would like to put the default server objects created by chef-icinga2 into a global zone.