### PR TITLE
cookbook uses invalid/non-functional mode for log directory

### DIFF
--- a/recipes/server_web2.rb
+++ b/recipes/server_web2.rb
@@ -32,7 +32,7 @@ end
 directory node['icinga2']['web2']['log_dir'] do
   owner node[node['icinga2']['web_engine']]['user']
   group node[node['icinga2']['web_engine']]['group']
-  mode '0665'
+  mode '0775'
 end
 
 # setup token


### PR DESCRIPTION
Every time chef runs it cuts off writes to the file log

```
icingaweb2[29906]: Cannot write to log file "/var/log/icingaweb2/icingaweb2.log" (SplFileObject::__construct(/var/log/icingaweb2/icingaweb2.log): failed to open stream: Permission denied)
```