### PR TITLE
Allow use of packages instead of pulling directly from Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ icinga2 CHANGELOG
 =================
 
 This file is used to list changes made in each version of the icinga2 cookbook.
+2.6.6
+-----
+
+- Jo Rhett - Allow the use of packages for icingaweb2 interface, provide more control of git checkout
 
 2.6.5
 -----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 icinga2 Cookbook
 ==================
 
-[![Cookbook](http://img.shields.io/badge/cookbook-v2.6.5-green.svg)](https://github.com/icinga/chef-icinga2)
+[![Cookbook](http://img.shields.io/badge/cookbook-v2.6.6-green.svg)](https://github.com/icinga/chef-icinga2)
 
 This is a [Chef] cookbook to manage [Icinga2] using Chef LWRP.
 
@@ -1968,17 +1968,26 @@ Above LWRP resource will apply `Dependency` to all `Host` objects for provided `
 
  * `default[:icinga2][:web2][:enable]` (default: `false`): whether to setup icingaweb2
 
- * `default[:icinga2][:web2][:source_url]` (default: `git://git.icinga.org/icingaweb2.git`):
+ * `default[:icinga2][:web2][:install_method]` (default: `package`): or `git`
 
- * `default[:icinga2][:web2][:version]` (default: `v2.0.0-beta3`): icingaweb2 git checkout version / branch / tag etc.
+ * `default[:icinga2][:web2][:package_action]` (default: `upgrade`): or `create` to avoid upgrades
 
- * `default[:icinga2][:web2][:web_root]` (default: `/usr/share/icingaweb2`): icingaweb2 web root location
+ * `default[:icinga2][:web2][:version]` (default: `2.0.0-5`): icingaweb2 package version
 
  * `default[:icinga2][:web2][:web_uri]` (default: `/icingaweb2`): icingweb2 web uri
 
  * `default[:icinga2][:web2][:conf_dir]` (default: `/etc/icingaweb2`): icingaweb2 config directory
 
  * `default[:icinga2][:web2][:log_dir]` (default: `/var/log/icingaweb2`): icingaweb2 log directory
+
+
+### Git Attributes
+
+ * `default[:icinga2][:web2][:source_url]` (default: `git://git.icinga.org/icingaweb2.git`):
+
+ * `default[:icinga2][:web2][:git_version]` (default: `v2.0.0`): icingaweb2 git checkout version / branch / tag etc.
+
+ * `default[:icinga2][:web2][:web_root]` (default: `/usr/share/icingaweb2`): icingaweb2 web checkout location
 
 
 ## Cookbook Ulimit Attributes

--- a/attributes/server_web2.rb
+++ b/attributes/server_web2.rb
@@ -1,8 +1,14 @@
 
 default['icinga2']['web2']['enable'] = false
-default['icinga2']['web2']['source_url'] = 'git://git.icinga.org/icingaweb2.git'
-default['icinga2']['web2']['version'] = 'v2.0.0-rc1'
-default['icinga2']['web2']['web_root'] = '/usr/share/icingaweb2'
+default['icinga2']['web2']['install_method'] = 'git'
+default['icinga2']['web2']['package_action'] = 'upgrade' # use 'install' to avoid upgrades
+default['icinga2']['web2']['package_version'] = '2.0.0'  # ignored if upgrade is used
 default['icinga2']['web2']['web_uri'] = '/icingaweb2'
 default['icinga2']['web2']['conf_dir'] = '/etc/icingaweb2'
 default['icinga2']['web2']['log_dir'] = '/var/log/icingaweb2'
+
+# To use versions from GitHub, set 'install_method' to 'git'
+default['icinga2']['web2']['source_url'] = 'git://git.icinga.org/icingaweb2.git'
+default['icinga2']['web2']['version'] = 'v2.0.0'      # or 'HEAD'
+default['icinga2']['web2']['git_action'] = 'checkout' # or 'sync' to stay up to date
+default['icinga2']['web2']['web_root'] = '/usr/share/icingaweb2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vir.khatri@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Icinga2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.6.5'
+version '2.6.6'
 
 depends 'apt'
 depends 'yum', '~> 3.0'

--- a/recipes/server_web2.rb
+++ b/recipes/server_web2.rb
@@ -48,9 +48,22 @@ file ::File.join(node['icinga2']['web2']['conf_dir'], 'setup.token') do
   mode 0660
 end
 
-git node['icinga2']['web2']['web_root'] do
-  repository node['icinga2']['web2']['source_url']
-  revision node['icinga2']['web2']['version']
-  user node[node['icinga2']['web_engine']]['user']
-  group node[node['icinga2']['web_engine']]['group']
+if node['icinga2']['web2']['install_method'] == 'package'
+  package 'icingaweb2' do
+    action  node['icinga2']['web2']['package_action']
+    version node['icinga2']['web2']['package_version'] + node['icinga2']['icinga2_version_suffix']
+      unless node['icinga2']['ignore_version'] || node['icinga2']['web2']['package_action'] == 'upgrade'
+    end
+  end
+else
+  package 'icingaweb2' do
+    action  'remove'
+  end
+  git node['icinga2']['web2']['web_root'] do
+    action node['icinga2']['web2']['git_action']
+    repository node['icinga2']['web2']['source_url']
+    revision node['icinga2']['web2']['version']
+    user node[node['icinga2']['web_engine']]['user']
+    group node[node['icinga2']['web_engine']]['group']
+  end
 end


### PR DESCRIPTION
Update web2 version to 2.0.0
Allow use of packages instead of pulling directly from Git
Allow git checkout to avoid upgrades when tracking Git HEAD

Right now there are no incompatible changes, although I think that in 2.7.0 you should change to install from package by default.