### PR TITLE
Day names need to be quoted in timeperiod definitions

### DIFF
--- a/templates/default/object.timeperiod.conf.erb
+++ b/templates/default/object.timeperiod.conf.erb
@@ -19,7 +19,7 @@
   ranges = {
   <% options['ranges'].each do |day, time| -%>
   <% if day && time -%>
-    <%= day -%> = <%= time.inspect %>
+    <%= day.inspect -%> = <%= time.inspect %>
   <% end -%>
   <% end -%>
   }


### PR DESCRIPTION
Without this change you get

````
/etc/icinga2/objects.d/timeperiod.conf(294):   display_name = "U.S. Holidays"
/etc/icinga2/objects.d/timeperiod.conf(295):   ranges = {
/etc/icinga2/objects.d/timeperiod.conf(296):     january 1 = "00:00-24:00"
                                                 ^
/etc/icinga2/objects.d/timeperiod.conf(297):     monday -1 may = "00:00-24:00"
/etc/icinga2/objects.d/timeperiod.conf(298):     july 4 = "00:00-24:00"
icinga2.service: control process exited, code=exited status=1
Failed to start Icinga host/service/network monitoring system.
Unit icinga2.service entered failed state.
````