### PR TITLE
Adds support to use "assign where" in usergroups

### DIFF
--- a/libraries/resource_usergroup.rb
+++ b/libraries/resource_usergroup.rb
@@ -15,6 +15,14 @@ class Chef
         @name = name
       end
 
+      def assign_where(arg = nil)
+        set_or_return(
+          :assign_where, arg,
+          :kind_of => Array,
+          :default => nil
+        )
+      end
+
       def display_name(arg = nil)
         set_or_return(
           :display_name, arg,
@@ -51,7 +59,7 @@ class Chef
         set_or_return(
           :resource_properties, arg,
           :kind_of => Array,
-          :default => %w(display_name groups zone)
+          :default => %w(assign_where display_name groups zone)
         )
       end
     end

--- a/templates/default/object.usergroup.conf.erb
+++ b/templates/default/object.usergroup.conf.erb
@@ -15,6 +15,11 @@ object UserGroup <%= object.inspect -%> {
   <% if options['groups'] && !options['groups'].empty? -%>
   groups = <%= options['groups'].sort.uniq.inspect %>
   <% end -%>
+  <% if options['assign_where'] -%>
+  <%- options['assign_where'].each do |a|-%>
+  assign where <%= a %>
+  <% end -%>
+  <% end -%>
 }
 
 <% end -%>


### PR DESCRIPTION
This commit allows the user to pass the `assign_where` statement to the `icinga2_usergroup`-resource.

For example:

```ruby
icinga2_usergroup 'oncall' do
  display_name 'On-Call'
  assign_where [
    'user.vars.isoncall'
  ]
end
```

Would result in the icinga2 usergroups file containing:

```
[...]
object UserGroup "oncall" {
        display_name = "On Call"
        assign where user.vars.isoncall
}
[...]
```

I have created an issue with your tracker at: https://dev.icinga.org/issues/10831