### PR TITLE
The "times"-parameter does not allow "-character

### DIFF
--- a/templates/default/object.applynotification.conf.erb
+++ b/templates/default/object.applynotification.conf.erb
@@ -37,7 +37,7 @@ apply Notification <%= object.inspect -%> to <%= options['object_type'] -%> {
   times = {
   <% options['times'].each do |var, value| %>
     <% if var && value -%>
-    <%= var %> = <%= value.inspect %>
+    <%= var %> = <%= value %>
     <%- end -%>
   <%- end -%>
   }

--- a/templates/default/object.notification.conf.erb
+++ b/templates/default/object.notification.conf.erb
@@ -46,7 +46,7 @@
   times = {
   <% options['times'].each do |var, value| %>
     <% if var && value -%>
-    <%= var %> = <%= value.inspect %>
+    <%= var %> = <%= value %>
     <%- end -%>
   <%- end -%>
   }


### PR DESCRIPTION
The "times"-parameter inside of the configuration blocks to arrange
{apply,}notifications does not allow "-character around the values of
the keys in the hash.

The template used for both these type invokes the #inspect function on
the value of the hash. Always surround the value with double
apostrophes.

This commit fixes that issue.