### PR TITLE
Escaping for icinga2_environment host objects 

### DIFF
--- a/libraries/icinga2.rb
+++ b/libraries/icinga2.rb
@@ -18,3 +18,42 @@ def icinga2_resource_create?(a)
     false
   end
 end
+
+def icinga_format(toplevel)
+  case toplevel
+  when Hash
+  rval = "{ "
+  when Array
+  rval = "[ "
+  when NilClass
+    return 'null'
+  when String, Float, Fixnum
+    return toplevel.inspect
+  when Symbol
+    return toplevel.to_s.inspect
+  else
+    return toplevel.inspect.to_s.inspect
+  end
+
+  rval += toplevel.collect do |k,v|
+    prefix = ''
+
+    target = k
+    case toplevel
+    when Hash
+        prefix += "#{icinga_format(k)} = "
+        target = v
+    end
+
+    prefix += icinga_format(target)
+  end.join(', ')
+
+  case toplevel
+  when Hash
+  rval += " }"
+  when Array
+  rval += " ]"
+  end
+
+  return rval
+end

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -1,0 +1,44 @@
+
+# This seems wrong, but I don't actually know how to do this
+require_relative '../../libraries/icinga2.rb'
+
+describe "#icinga_format" do
+  subject { icinga_format }
+
+  it "handles hashes" do
+    expect(icinga_format({:foo => :bar})).to eq('{ "foo" = "bar" }')
+  end
+
+  it "handles arrays" do
+    expect(icinga_format([1,3,5])).to eq('[ 1, 3, 5 ]')
+  end
+
+  it "handles strings" do
+    expect(icinga_format("foo")).to eq('"foo"')
+  end
+
+  it "handles floats" do
+    expect(icinga_format(1.2)).to eq('1.2')
+  end
+
+  it "handles fixnums" do
+    expect(icinga_format(10)).to eq('10')
+  end
+
+  it "handles nulls" do
+    expect(icinga_format(nil)).to eq("null")
+  end
+
+  it "handles nesting" do
+    expect(icinga_format({:foo => [:bar, {1=>2}, {1=>[:a,:b,:c]}]})).to eq('{ "foo" = [ "bar", { 1 = 2 }, { 1 = [ "a", "b", "c" ] } ] }')
+  end
+
+  it "handles arbitrary objects by stringifying them" do
+    expect(icinga_format(StandardError.new)).to eq('"#<StandardError: StandardError>"')
+  end
+
+  it "Arbitrary stringifying works with nesting" do
+    expect(icinga_format({"err"=>StandardError.new, "list"=>[{"err"=>IOError.new}]})).to eq('{ "err" = "#<StandardError: StandardError>", "list" = [ { "err" = "#<IOError: IOError>" } ] }')
+  end
+
+end

--- a/templates/default/object.environment.conf.erb
+++ b/templates/default/object.environment.conf.erb
@@ -89,19 +89,19 @@ object Host <%= node_hash['fqdn'].inspect %> {
   <% if var && value && value.is_a?(Hash) -%>
   <% value.each do |a, v|-%>
   <% if a && v && v.is_a?(Hash) && !v.empty?-%>
-  vars.<%= var -%><%= [a].inspect -%> = {
+  vars["<%= var -%>"][<%= a.inspect -%>] = {
   <% v.each do |a1, v1|%>
   <% if a1 && v1 %>
-  <%= a1 -%> = <%= v1.inspect %>
+  "<%= a1 -%>" = <%= icinga_format(v1) %>
   <% end -%>
   <% end -%>
   }
   <% else -%>
-  vars.<%= var -%><%= [a].inspect -%> = <%= v.inspect %>
+  vars["<%= var -%>"][<%= a.inspect -%>] = <%= icinga_format(v) %>
   <% end -%>
   <% end -%>
   <% elsif var && value -%>
-  vars.<%= var -%> = <%= value.inspect %>
+  vars["<%= var -%>"] = <%= icinga_format(value) %>
   <% end -%>
   <% end -%>
   <% end -%>


### PR DESCRIPTION
[Issue 11453](https://dev.icinga.org/issues/11453)

As background, I've been pretty aggressive about dumping lots of Chef node data into host objects. It really reduces the friction of doing fine-grained `assign where` work. After upgrading to Icinga 2.4.4, my templates all broke.

This patch includes a new library function, `icinga_format`, that should do a pretty reasonable job of converting Ruby data into Icinga-language data. My environment searches, with all their node data, seem to work again. I also included some small changes to the template used by environment searches to make my use case go.

That said, I think that most of the templates- and even parts of the template I changed- could use a thorough going-over, and applying of the new `icinga_format` function so that things are escaped properly, everywhere. I'm a little reluctant to go down that route as someone new to the codebase, but if you're open to it I might give it a shot. [Issue 11031](https://dev.icinga.org/issues/11031), for instance, could probably be fixed via `icinga_format`.