### PR TITLE
Debian support

### DIFF
--- a/recipes/server_apache.rb
+++ b/recipes/server_apache.rb
@@ -48,21 +48,21 @@ apache_config 'icinga2-web2' if node['icinga2']['web2']['enable']
 
 # group resource for user nagios
 group node['icinga2']['group'] do
-  only_if { node['platform'] == 'ubuntu' }
+  only_if { node['platform_family'] == 'debian' }
   append true
 end
 
 user 'nagios' do
   gid 'nagios'
   system true
-  only_if { node['platform'] == 'ubuntu' }
+  only_if { node['platform_family'] == 'debian' }
 end
 
 # add group members
 group "manage_members_#{node['icinga2']['group']}" do
   group_name node['icinga2']['group']
   members [node['apache']['user'], node['icinga2']['user']]
-  only_if { node['platform'] == 'ubuntu' }
+  only_if { node['platform_family'] == 'debian' }
   notifies :restart, 'service[apache2]', :delayed
   action :modify
 end

--- a/recipes/server_classic_ui.rb
+++ b/recipes/server_classic_ui.rb
@@ -63,7 +63,7 @@ end
 template 'icinga2_classic_ui_htpasswd' do
   path value_for_platform(
     %w(centos redhat fedora amazon) => { 'default' => ::File.join(node['icinga2']['classic_ui']['conf_dir'], 'passwd') },
-    'ubuntu' => { 'default' => ::File.join(node['icinga2']['classic_ui']['conf_dir'], 'htpasswd.users') }
+    %w(debian ubuntu) => { 'default' => ::File.join(node['icinga2']['classic_ui']['conf_dir'], 'htpasswd.users') }
   )
   source 'icinga2.passwd.erb'
   owner 'root'


### PR DESCRIPTION
To allow the cookbook to converge successfully on Debian as well as Ubuntu, a number of uses of `node['platform'] == 'ubuntu' `need to be replaced with `node['platform_family'] == 'debian'` as well as adding `debian` into the value_for_platform helper list.

Thanks!