### PR TITLE
Add merge_vars attribute to applyservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,12 +896,13 @@ Above LWRP resource will apply an icinga `Service` object to all `Hosts` with cu
 	  import 'generic-service'
 	  check_command 'check_snmp'
 	  assign_where ['"areca" in host.vars.enabled_services']
+	  merge_vars ['config']
 	  check_interval '5m'
 	  retry_interval '3m'
 	  max_check_attempts 2
 	end
 
-Above LWRP resource will apply an icinga `Service` object with a Service for set (also called hash or dictionary) to all `Hosts` with custom vars `host.vars.enabled_services` including 'areca'.
+Above LWRP resource will apply an icinga `Service` object with a Service for set (also called hash or dictionary) to all `Hosts` with custom vars `host.vars.enabled_services` including 'areca'. It will also merge the values in `config` into the `Service` object.
 
 
 **LWRP Options**
@@ -936,6 +937,7 @@ Above LWRP resource will apply an icinga `Service` object with a Service for set
 - *icon_image* (optional, String)	- icinga `Service` object attribute `icon_image`
 - *icon_image_alt* (optional, String)	- icinga `Service` object attribute `icon_image_alt`
 - *custom_vars* (optional, Hash)	- icinga `Service` object attribute `vars`
+- *merge_vars* (optional, Array)	- Merge vars from each member of a set into icinga `Service` object attribute `vars`
 - *assign_where* (optional, Array)	 - an array of `assign where` statements
 - *ignore_where* (optional, Array)	 - an array of `ignore where` statements
 

--- a/libraries/resource_applyservice.rb
+++ b/libraries/resource_applyservice.rb
@@ -214,6 +214,14 @@ class Chef
         )
       end
 
+      def merge_vars(arg = nil)
+        set_or_return(
+          :merge_vars, arg,
+          :kind_of => Array,
+          :default => nil
+        )
+      end
+
       def custom_vars(arg = nil)
         set_or_return(
           :custom_vars, arg,
@@ -259,7 +267,7 @@ class Chef
         set_or_return(
           :resource_properties, arg,
           :kind_of => Array,
-          :default => %w(import display_name host_name groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars assign_where ignore_where set)
+          :default => %w(import display_name host_name groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt merge_vars custom_vars assign_where ignore_where set)
         )
       end
     end

--- a/templates/default/object.applyservice.conf.erb
+++ b/templates/default/object.applyservice.conf.erb
@@ -8,7 +8,7 @@
 */
 
 <% @objects.sort.map do |object, options|%>
-apply Service <%= options['set'].nil? ? object.inspect : "for (#{options['set']})" -%> {
+apply Service <%= object.inspect -%><%= " for (#{options['set']})" unless options['set'].nil? -%> {
   <%- if options['import'] -%>
   import <%= options['import'].inspect %>
   <%- end -%>
@@ -89,6 +89,11 @@ apply Service <%= options['set'].nil? ? object.inspect : "for (#{options['set']}
   <% if options['ignore_where'] -%>
   <% options['ignore_where'].each do |i| -%>
   ignore where <%= i %>
+  <% end -%>
+  <% end -%>
+  <% if options['merge_vars'] -%>
+  <% options['merge_vars'].each do |var| -%>
+  vars += <%= var %>
   <% end -%>
   <% end -%>
   <% if options['custom_vars'] -%>


### PR DESCRIPTION
Add merge_vars attribute to applyservice LWRP to support [3.5.7. Use Object Attributes in Apply Rules](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/monitoring-basics#using-apply-object-attributes)

Also allows for multiple Service objects to be created from the same set by always using the  icinga2_applyservice resource name in the Service object, rather than only when not using a set e.g.:
http_vhosts_example.com
http_vhost_example.com

Previously, when using the same set with two icinga2_applyservice resources this would only have used the set key as the Service name and created two Service objects named:
example.com
example.com

Please let me know if there is anything else you wish done so this can be merged. Thanks!