### PR TITLE
Add user and group attributes to logrotate template

### DIFF
--- a/recipes/core_config.rb
+++ b/recipes/core_config.rb
@@ -63,7 +63,7 @@ template '/etc/logrotate.d/icinga2' do
   owner 'root'
   group 'root'
   mode 0o644
-  variables(:log_dir => node['icinga2']['log_dir'])
+  variables(:log_dir => node['icinga2']['log_dir'], :user => node['icinga2']['user'], :group => node['icinga2']['group'])
 end
 
 # icinga2.conf

--- a/templates/default/icinga2.logrotate.erb
+++ b/templates/default/icinga2.logrotate.erb
@@ -4,32 +4,31 @@
 #
 
 <%= @log_dir -%>/icinga2.log <%= @log_dir -%>/debug.log {
-  daily
+	daily
 	rotate 7
-	su icinga icinga
+	su <%= @user -%> <%= @group %>
 	compress
 	delaycompress
-  missingok
-  notifempty
-  create 644 icinga icinga
+	missingok
+	notifempty
+	create 644 <%= @user -%> <%= @group %>
 	copytruncate
 	postrotate
 		if ! killall -q -USR1 icinga2; then
 			exit 1
 		fi
-  endscript
+	endscript
 }
 
 <%= @log_dir -%>/error.log {
 	daily
-	su icinga icinga
+	su <%= @user -%> <%= @group %>
 	rotate 90
 	compress
 	delaycompress
 	missingok
 	notifempty
-	create 644 icinga icinga
+	create 644 <%= @user -%> <%= @group %>
 	copytruncate
 	# TODO: figure out how to get Icinga to re-open this log file
 }
-


### PR DESCRIPTION
Logrotate template should use the `node['icinga2']['user']` and `node['icinga2']['group']` attributes, currently icinga user and group are assumed.

Thanks!