### PR TITLE
Allow re-notifications to be disabled

### DIFF
--- a/libraries/resource_applynotification.rb
+++ b/libraries/resource_applynotification.rb
@@ -67,7 +67,7 @@ class Chef
         set_or_return(
           :interval, arg,
           :kind_of => [String, Integer],
-          :regex => /^\d+[smhd]$/,
+          :regex => /^0|\d+[smhd]$/,
           :default => nil
         )
       end


### PR DESCRIPTION
As per [Monitoring Basics 3.7.3. Disable Re-notifications](http://docs.icinga.org/icinga2/latest/doc/module/icinga2/toc#!/icinga2/latest/doc/module/icinga2/chapter/monitoring-basics#disable-renotification), the regex for interval attribute of applynotification resource should permit 0 as a value in order to allow re-notifications to be disabled.

Thanks!