### PR TITLE
Fix missing parent attribute for icinga2_envzone

### DIFF
--- a/libraries/resource_envzone.rb
+++ b/libraries/resource_envzone.rb
@@ -106,7 +106,8 @@ class Chef
             :environment => new_resource.environment,
             :zones => new_resource.zones,
             :zone => new_resource.zone,
-            :log_duration => new_resource.log_duration
+            :log_duration => new_resource.log_duration,
+            :parent => new_resource.parent
           )
           notifies :reload, 'service[icinga2]'
         end


### PR DESCRIPTION
Previously parent variable was missing from template  in icinga2_envzone and thus does not show up in template file.
