### PR TITLE
Makes Ubuntu Xenial Xerus use PHP 5.6 instead of 5.5.

### DIFF
--- a/recipes/server_os_packages.rb
+++ b/recipes/server_os_packages.rb
@@ -33,11 +33,11 @@ when 'debian'
                      php5-imagick php-pear php5-xmlrpc php5-xsl php5-mysql
                      php-soap php5-gd php5-ldap php5-pgsql php5-intl)
   when 'xenial'
-    os_packages = %w(g++ mailutils php5.5 php5.5-cli php5.5-fpm build-essential
+    os_packages = %w(g++ mailutils php5.6 php5.6-cli php5.6-fpm build-essential
                      libgd2-xpm-dev libjpeg62 libpng12-0
-                     libpng12-dev libapache2-mod-php5.5 imagemagick
-                     php5.5-imagick php-pear php5.5-xmlrpc php5.5-xsl php5.5-mysql
-                     php-soap php5.5-gd php5.5-ldap php5.5-pgsql php5.5-intl)
+                     libpng12-dev libapache2-mod-php5.6 imagemagick
+                     php5.6-imagick php-pear php5.6-xmlrpc php5.6-xsl php5.6-mysql
+                     php-soap php5.6-gd php5.6-ldap php5.6-pgsql php5.6-intl)
   end
 
   apt_repository 'ondrej-php' do

--- a/recipes/server_web2.rb
+++ b/recipes/server_web2.rb
@@ -52,7 +52,7 @@ end
 php_ini = if node['platform_family'] == 'rhel'
             '/etc/php.ini'
           elsif node['lsb']['codename'] == 'xenial'
-            '/etc/php/5.5/apache2/php.ini'
+            '/etc/php/5.6/apache2/php.ini'
           else
             '/etc/php5/apache2/php.ini'
           end


### PR DESCRIPTION
As I was converging a testnode with Xenial, I noticed php 5.5 has some dependency hell when trying to install php5.5 (concerning php-apcu and php-yac). As icingaweb2 is compatible with PHP 5.6, I see no issue updating this.