### PR TITLE
Updates the web2 git source url

### DIFF
--- a/attributes/server_web2.rb
+++ b/attributes/server_web2.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 default['icinga2']['web2']['enable'] = false
 default['icinga2']['web2']['install_method'] = 'package' # source
-default['icinga2']['web2']['source_url'] = 'git://git.icinga.org/icingaweb2.git'
+default['icinga2']['web2']['source_url'] = 'https://github.com/Icinga/icingaweb2.git'
 default['icinga2']['web2']['version'] = '2.3.4'
 default['icinga2']['web2']['release'] = value_for_platform(
   %w(centos redhat fedora amazon) => { 'default' => '1' }


### PR DESCRIPTION
We were having failed Chef runs because the old repository seems to be gone. It looks like this is the new repository used for the web2 interface?