### PR TITLE
Ubuntu 16.04 Compatibility updates

### DIFF
--- a/recipes/server_os_packages.rb
+++ b/recipes/server_os_packages.rb
@@ -33,11 +33,11 @@ when 'debian'
                      php5-imagick php-pear php5-xmlrpc php5-xsl php5-mysql
                      php-soap php5-gd php5-ldap php5-pgsql php5-intl)
   when 'xenial'
-    os_packages = %w(g++ mailutils php5.5 php5.5-cli php5.5-fpm build-essential
-                     libgd2-xpm-dev libjpeg62 libpng12-0
-                     libpng12-dev libapache2-mod-php5.5 imagemagick
-                     php5.5-imagick php-pear php5.5-xmlrpc php5.5-xsl php5.5-mysql
-                     php-soap php5.5-gd php5.5-ldap php5.5-pgsql php5.5-intl)
+    os_packages = %w(g++ mailutils php5.6 php5.6-cli php5.6-fpm build-essential
+                   libgd2-xpm-dev libjpeg62 libpng12-0
+                   libpng12-dev libapache2-mod-php5.6 imagemagick
+                   php5.6-imagick php-pear php5.6-xmlrpc php5.6-xsl php5.6-mysql
+                   php-soap php5.6-gd php5.6-ldap php5.6-pgsql php5.6-intl)
   end
 
   apt_repository 'ondrej-php' do

--- a/recipes/server_web2.rb
+++ b/recipes/server_web2.rb
@@ -49,14 +49,17 @@ file ::File.join(node['icinga2']['web2']['conf_dir'], 'setup.token') do
 end
 
 # set php time zone
-php_ini = if node['platform_family'] == 'rhel'
-            '/etc/php.ini'
-          elsif node['lsb']['codename'] == 'xenial'
-            '/etc/php/5.5/apache2/php.ini'
-          else
-            '/etc/php5/apache2/php.ini'
-          end
-
+case node['platform_family']
+when 'debian'
+  case node['lsb']['codename']
+  when 'trusty'
+    php_ini = '/etc/php5/apache2/php.ini'
+  when 'xenial'
+    php_ini = '/etc/php/5.6/apache2/php.ini'
+  end
+when 'rhel'
+   php_ini = '/etc/php.ini'
+end
 ruby_block 'set php timezone' do
   block do
     fe = Chef::Util::FileEdit.new(php_ini)

--- a/recipes/server_web2.rb
+++ b/recipes/server_web2.rb
@@ -52,7 +52,7 @@ end
 php_ini = if node['platform_family'] == 'rhel'
             '/etc/php.ini'
           elsif node['lsb']['codename'] == 'xenial'
-            '/etc/php/5.5/apache2/php.ini'
+            '/etc/php/5.6/apache2/php.ini'
           else
             '/etc/php5/apache2/php.ini'
           end

--- a/recipes/server_web2.rb
+++ b/recipes/server_web2.rb
@@ -49,17 +49,14 @@ file ::File.join(node['icinga2']['web2']['conf_dir'], 'setup.token') do
 end
 
 # set php time zone
-case node['platform_family']
-when 'debian'
-  case node['lsb']['codename']
-  when 'trusty'
-    php_ini = '/etc/php5/apache2/php.ini'
-  when 'xenial'
-    php_ini = '/etc/php/5.6/apache2/php.ini'
-  end
-when 'rhel'
-   php_ini = '/etc/php.ini'
-end
+php_ini = if node['platform_family'] == 'rhel'
+            '/etc/php.ini'
+          elsif node['lsb']['codename'] == 'xenial'
+            '/etc/php/5.5/apache2/php.ini'
+          else
+            '/etc/php5/apache2/php.ini'
+          end
+
 ruby_block 'set php timezone' do
   block do
     fe = Chef::Util::FileEdit.new(php_ini)


### PR DESCRIPTION
Out of the box, Ubuntu 16.04 Xenial does not support installing PHP 5.5. I've updated the versions of the server packages in server_os_packages (specifically for Xenial) to reflect this, and I updated where on disk Icinga looks for the PHP.ini file which, in the case of Xenial using PHP5.6, is at /etc/php/5.6/apache2/php.ini

Because I need this to work in production, I've been applying my changes directly on top of 2.9.1, so I can't say for certain that this all works on the HEAD, but unless some very strange compatibility-breaking changes have been made since then, this code should work fine.

In short, without these changes, running the Icinga cookbook on Ubuntu 16.04 always fails. With these changes, it succeeds, at least for me.