### PR TITLE
Add notification_period by copying check_period

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ Above LWRP resource will create `Host` objects for a chef environment nodes for 
 - *check_command* (optional, String)	- icinga `Host` object attribute `check_command`
 - *max_check_attempts* (optional, Integer)	- icinga `Host` object attribute `max_check_attempts`
 - *check_period* (optional, String)	- icinga `Host` object attribute `check_period`
+- *notification_period* (optional, String)	- icinga `Host` object attribute `notification_period`
 - *check_interval* (optional, String/Integer)	- icinga `Host` object attribute `check_interval`
 - *retry_interval* (optional, Integer)	- icinga `Host` object attribute `retry_interval`
 - *enable_notifications* (optional, TrueClass/FalseClass)	- icinga `Host` object attribute `enable_notifications`
@@ -855,6 +856,7 @@ Above LWRP resource will create an icinga `Host` template - `generic-host`.
 - *check_command* (optional, String)	- icinga `Host` object attribute `check_command`
 - *max_check_attempts* (optional, Integer)	- icinga `Host` object attribute `max_check_attempts`
 - *check_period* (optional, String)	- icinga `Host` object attribute `check_period`
+- *notification_period* (optional, String)	- icinga `Host` object attribute `notification_period`
 - *check_interval* (optional, String/Integer)	- icinga `Host` object attribute `check_interval`
 - *retry_interval* (optional, String/Integer)	- icinga `Host` object attribute `retry_interval`
 - *enable_notifications* (optional, TrueClass/FalseClass)	- icinga `Host` object attribute `enable_notifications`
@@ -946,6 +948,7 @@ Above LWRP resource will create an icinga `Service` template object for a `gener
 - *check_command* (optional)	- icinga `Service` object attribute `check_command`
 - *max_check_attempts* (optional)	- icinga `Service` object attribute `max_check_attempts`
 - *check_period* (optional)	- icinga `Service` object attribute `check_period`
+- *notification_period* (optional)	- icinga `Service` object attribute `notification_period`
 - *check_interval* (optional)	- icinga `Service` object attribute `check_interval`
 - *retry_interval* (optional)	- icinga `Service` object attribute `retry_interval`
 - *enable_notifications* (optional, TrueClass/FalseClass)	- icinga `Service` object attribute `enable_notifications`
@@ -1019,6 +1022,7 @@ Above LWRP resource will apply an icinga `Service` object with a Service for set
 - *check_command* (optional, String)	- icinga `Service` object attribute `check_command`
 - *max_check_attempts* (optional, Integer)	- icinga `Service` object attribute `max_check_attempts`
 - *check_period* (optional, String)	- icinga `Service` object attribute `check_period`
+- *notification_period* (optional, String)	- icinga `Service` object attribute `notification_period`
 - *check_interval* (optional, String/Integer)	- icinga `Service` object attribute `check_interval`
 - *retry_interval* (optional, String/Integer)	- icinga `Service` object attribute `retry_interval`
 - *enable_notifications* (optional, TrueClass/FalseClass)	- icinga `Service` object attribute `enable_notifications`
@@ -2071,6 +2075,8 @@ Above LWRP resource will apply `Dependency` to all `Host` objects for provided `
 * `default['icinga2']['server']['object']['host']['max_check_attempts']` (default: `3`)
 
 * `default['icinga2']['server']['object']['host']['check_period']` (default: `nil`)
+
+* `default['icinga2']['server']['object']['host']['notification_period']` (default: `nil`)
 
 * `default['icinga2']['server']['object']['host']['check_interval']` (default: `1800`)
 

--- a/attributes/server_objects.rb
+++ b/attributes/server_objects.rb
@@ -4,6 +4,7 @@ default['icinga2']['server']['object']['global-templates'] = false
 default['icinga2']['server']['object']['host']['import'] = 'generic-host'
 default['icinga2']['server']['object']['host']['max_check_attempts'] = 3
 default['icinga2']['server']['object']['host']['check_period'] = nil
+default['icinga2']['server']['object']['host']['notification_period'] = nil
 default['icinga2']['server']['object']['host']['check_interval'] = '1m'
 default['icinga2']['server']['object']['host']['retry_interval'] = '30s'
 default['icinga2']['server']['object']['host']['enable_notifications'] = true

--- a/libraries/provider_environment.rb
+++ b/libraries/provider_environment.rb
@@ -97,6 +97,7 @@ class Chef
                     :check_command => new_resource.check_command,
                     :max_check_attempts => new_resource.max_check_attempts,
                     :check_period => new_resource.check_period,
+                    :notification_period => new_resource.notification_period,
                     :check_interval => new_resource.check_interval,
                     :retry_interval => new_resource.retry_interval,
                     :enable_notifications => new_resource.enable_notifications,

--- a/libraries/resource_applyservice.rb
+++ b/libraries/resource_applyservice.rb
@@ -79,6 +79,14 @@ class Chef
         )
       end
 
+      def notification_period(arg = nil)
+        set_or_return(
+          :notification_period, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
       def check_interval(arg = nil)
         set_or_return(
           :check_interval, arg,
@@ -276,7 +284,7 @@ class Chef
         set_or_return(
           :resource_properties, arg,
           :kind_of => Array,
-          :default => %w(import display_name host_name groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt merge_vars custom_vars assign_where ignore_where set)
+          :default => %w(import display_name host_name groups check_command max_check_attempts check_period notification_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt merge_vars custom_vars assign_where ignore_where set)
         )
       end
     end

--- a/libraries/resource_environment.rb
+++ b/libraries/resource_environment.rb
@@ -252,6 +252,14 @@ class Chef
         )
       end
 
+      def notification_period(arg = nil)
+        set_or_return(
+          :notification_period, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
       def check_interval(arg = nil)
         set_or_return(
           :check_interval, arg,

--- a/libraries/resource_host.rb
+++ b/libraries/resource_host.rb
@@ -87,6 +87,14 @@ class Chef
         )
       end
 
+      def notification_period(arg = nil)
+        set_or_return(
+          :notification_period, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
       def check_interval(arg = nil)
         set_or_return(
           :check_interval, arg,
@@ -259,7 +267,7 @@ class Chef
         set_or_return(
           :resource_properties, arg,
           :kind_of => Array,
-          :default => %w(import display_name address address6 groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars template)
+          :default => %w(import display_name address address6 groups check_command max_check_attempts check_period notification_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars template)
         )
       end
     end

--- a/libraries/resource_service.rb
+++ b/libraries/resource_service.rb
@@ -79,6 +79,14 @@ class Chef
         )
       end
 
+      def notification_period(arg = nil)
+        set_or_return(
+          :notification_period, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
       def check_interval(arg = nil)
         set_or_return(
           :check_interval, arg,
@@ -251,7 +259,7 @@ class Chef
         set_or_return(
           :resource_properties, arg,
           :kind_of => Array,
-          :default => %w(import display_name host_name groups check_command max_check_attempts check_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars template)
+          :default => %w(import display_name host_name groups check_command max_check_attempts check_period notification_period check_interval retry_interval enable_notifications enable_active_checks enable_passive_checks enable_event_handler enable_flapping enable_perfdata event_command flapping_threshold volatile zone command_endpoint notes notes_url action_url icon_image icon_image_alt custom_vars template)
         )
       end
     end

--- a/templates/default/object.applyservice.conf.erb
+++ b/templates/default/object.applyservice.conf.erb
@@ -30,6 +30,9 @@ apply Service <%= object.inspect -%><%= " for (#{options['set']})" unless option
   <%- if options['check_period'] -%>
   check_period = <%= options['check_period'].inspect %>
   <%- end -%>
+  <%- if options['notification_period'] -%>
+  notification_period = <%= options['notification_period'].inspect %>
+  <%- end -%>
   <%- if options['check_interval'] -%>
   check_interval = <%= options['check_interval'] %>
   <%- end -%>

--- a/templates/default/object.environment.conf.erb
+++ b/templates/default/object.environment.conf.erb
@@ -33,6 +33,9 @@ object Host <%= node_hash['fqdn'].inspect %> {
   <%- if @check_period -%>
   check_period = <%= @check_period.inspect %>
   <%- end -%>
+  <%- if @notification_period -%>
+  notification_period = <%= @notification_period.inspect %>
+  <%- end -%>
   <%- if @check_interval -%>
   check_interval = <%= @check_interval %>
   <%- end -%>

--- a/templates/default/object.host.conf.erb
+++ b/templates/default/object.host.conf.erb
@@ -33,6 +33,9 @@
   <%- if options['check_period'] -%>
   check_period = <%= options['check_period'].inspect %>
   <%- end -%>
+  <%- if options['notification_period'] -%>
+  notification_period = <%= options['notification_period'].inspect %>
+  <%- end -%>
   <%- if options['check_interval'] -%>
   check_interval = <%= options['check_interval'] %>
   <%- end -%>

--- a/templates/default/object.service.conf.erb
+++ b/templates/default/object.service.conf.erb
@@ -30,6 +30,9 @@
   <%- if options['check_period'] -%>
   check_period = <%= options['check_period'].inspect %>
   <%- end -%>
+  <%- if options['notification_period'] -%>
+  notification_period = <%= options['notification_period'].inspect %>
+  <%- end -%>
   <%- if options['check_interval'] -%>
   check_interval = <%= options['check_interval'] %>
   <%- end -%>


### PR DESCRIPTION
Icinga comes with both a `check_period` and `notification_period`.  We would like to use the latter, so that the checks are run all of the time, but we are only notified of problems during support hours.

I have therefore created a PR with what I think are the required changes - duplicating all lines that have `check_period` in to add `notification_period`.