### PR TITLE
Add all roles to generated hostgroups for a node

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12.19.36
   <% if chef_omnibus_url %>
   chef_omnibus_url: '<%= chef_omnibus_url %>'
   <% end %>
@@ -26,6 +27,9 @@ suites:
     run_list:
       - recipe[icinga2::server]
       - recipe[icinga2-test::default]
+    attributes:
+      icinga2:
+        enable_role_hostgroup: false
 
   - name: client
     run_list:

--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -30,7 +30,7 @@ require 'resolv'
 module Icinga2
   # fetch node information into Hash
   class Search
-    attr_accessor :query, :environment, :enable_cluster_hostgroup, :cluster_attribute,
+    attr_accessor :query, :environment, :enable_cluster_hostgroup, :enable_role_hostgroup, :cluster_attribute,
                   :enable_application_hostgroup, :application_attribute, :ignore_node_error,
                   :ignore_resolv_error, :exclude_recipes, :exclude_roles, :env_custom_vars,
                   :limit_region, :server_region, :search_pattern, :use_fqdn_resolv,
@@ -43,6 +43,7 @@ module Icinga2
       @enable_cluster_hostgroup = options[:enable_cluster_hostgroup]
       @cluster_attribute = options[:cluster_attribute]
       @enable_application_hostgroup = options[:enable_application_hostgroup]
+      @enable_role_hostgroup = options[:enable_role_hostgroup]
       @application_attribute = options[:application_attribute]
       @ignore_node_error = options[:ignore_node_error]
       @ignore_resolv_error = options[:ignore_resolv_error]
@@ -163,6 +164,11 @@ module Icinga2
           end
         else
           node_hash['custom_vars']['hostgroups'] = [node_hash['chef_environment']]
+        end
+
+        # collect nodes roles
+        if enable_role_hostgroup
+          node_hash['custom_vars']['hostgroups'].push(*(roles.map { |r| node_hash['chef_environment'] + '-' + r }))
         end
 
         # collect nodes cluster

--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -168,7 +168,7 @@ module Icinga2
 
         # collect nodes roles
         if enable_role_hostgroup
-          node_hash['custom_vars']['hostgroups'].push(*(roles.map { |r| node_hash['chef_environment'] + '-' + r }))
+          node_hash['custom_vars']['hostgroups'].push(*(node_hash['roles'].map { |r| node_hash['chef_environment'] + '-' + r }))
         end
 
         # collect nodes cluster


### PR DESCRIPTION
If `enable_role_hostgroup` is enabled to generate the hostgroup files, we more than likely want to have hosts that belong to said hostgroup have their roles reported so that the `assign where` works appropriately.