### PR TITLE
Allow "item in host.vars.bar" syntax in icinga2_applyservice

### DIFF
--- a/libraries/resource_applyservice.rb
+++ b/libraries/resource_applyservice.rb
@@ -267,7 +267,7 @@ class Chef
         set_or_return(
           :set, arg,
           :kind_of => String,
-          :regex => /^[a-z|_]+\s=>\s[a-z|_]+\sin\s\S+$/,
+          :regex => /^([a-z|_]+\s=>\s)?[a-z|_]+\sin\s\S+$/,
           :default => nil
         )
       end


### PR DESCRIPTION
The current upstream only allows to access hash values when using the extended `apply service` syntax using `set`. I have a use case where I need to iterate over an array, but the resource does not accept this (valid) syntax:

```ruby
icinga2_host "host" do
  custom_vars("bar" => ["one", "two"])
end

icinga2_apply_service "svc" do
  set 'item in host.vars.bar'
end
```

By adding a quick change to the Regexp, this is now supported