### PR TITLE
Fix provider instance

### DIFF
--- a/libraries/provider_instance.rb
+++ b/libraries/provider_instance.rb
@@ -24,7 +24,7 @@ class Chef
 
       # collect object defined resources
       def object_resources
-        run_context.resource_collection.select do |resource|
+        Chef.run_context.resource_collection.select do |resource|
           case new_resource.resource_name
           when :icinga2_apilistener
             resource.is_a?(Chef::Resource::Icinga2Apilistener)


### PR DESCRIPTION
Without this LWRP did not work at all for me becuase run_context.resource_collection.select would always return an empty object.
Maybe we should add some tests for resources other than the basic installation, too :)