### PR TITLE
Fix: Pass array to the `package` provider

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,8 +2,8 @@
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/getting-started#getting-started
 
 default['icinga2']['version'] = value_for_platform(
-  %w(centos redhat fedora amazon) => { 'default' => '2.6.3-1' },
-  %w(debian ubuntu raspbian) => { 'default' => '2.6.3-1' }
+  %w(centos redhat fedora amazon) => { 'default' => '2.7.0-1' },
+  %w(debian ubuntu raspbian) => { 'default' => '2.7.0-1' }
 )
 
 default['icinga2']['enable_env_pki'] = false

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -20,7 +20,7 @@ when 'rhel'
   # icinga2 package version suffix
   default['icinga2']['icinga2_version_suffix'] = value_for_platform(
     %w(centos redhat fedora) => { 'default' => ".el#{node['platform_version'].split('.')[0]}",
-                                  '>= 7.0' => '.el7.centos' },
+                                  '>= 7.0' => '.el7.icinga' },
     'amazon' => { 'default' => '.el6' }
   )
 

--- a/recipes/server_os_packages.rb
+++ b/recipes/server_os_packages.rb
@@ -58,6 +58,4 @@ when 'rhel'
 end
 
 # dependencies
-os_packages.each do |p|
-  package p
-end
+package os_packages unless os_packages.empty?


### PR DESCRIPTION
The generic `package` provider supports passing an array of packages, and the implementing providers can use the array to install all packages in one transaction, speeding up installation.

I included the postfix `unless` to preserve the behavior of declaring nothing when `os_packages` is an empty array.

I also updated the versions installed to match what the icinga2 repo is serving. This includes updating the version suffix for RHEL 7 and related - which seems to have changed.