### PR TITLE
Add cookbook for apache conf templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2077,6 +2077,8 @@ Above LWRP resource will apply `Dependency` to all `Host` objects for provided `
 
 * `default['icinga2']['apache_modules']` (default: `calculated`): apache modules / apache2 cookbook recipe to enable
 
+* `default['icinga2']['apache_conf_cookbook']` (default: `icinga2`): cookbook for apache templates
+
 
 ## Cookbook Icinga2 Constants Attributes
 

--- a/README.md
+++ b/README.md
@@ -2079,6 +2079,10 @@ Above LWRP resource will apply `Dependency` to all `Host` objects for provided `
 
 * `default['icinga2']['apache_conf_cookbook']` (default: `icinga2`): cookbook for apache templates
 
+* `default['icinga2']['apache_classic_ui_template']` (default: `apache.vhost.icinga2_classic_ui.conf.#{node['platform_family']}.erb`): apache template for classic ui
+
+* `default['icinga2']['apache_web2_template']` (default: `apache.vhost.icinga2_web2.erb`): apache template for icingaweb2
+
 
 ## Cookbook Icinga2 Constants Attributes
 

--- a/attributes/server_apache.rb
+++ b/attributes/server_apache.rb
@@ -8,3 +8,5 @@ default['icinga2']['apache_modules'] = value_for_platform(
   %w(centos redhat fedora) => { '>= 7.0' => %w(default mod_wsgi mod_php5 mod_cgi mod_ssl mod_rewrite),
                                 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) }
 )
+
+default['icinga2']['apache_conf_cookbook'] = 'icinga2'

--- a/attributes/server_apache.rb
+++ b/attributes/server_apache.rb
@@ -9,4 +9,6 @@ default['icinga2']['apache_modules'] = value_for_platform(
                                 'default' => %w(default mod_python mod_php5 mod_cgi mod_ssl mod_rewrite) }
 )
 
+default['icinga2']['apache_classic_ui_template'] = "apache.vhost.icinga2_classic_ui.conf.#{node['platform_family']}.erb"
+default['icinga2']['apache_web2_template'] = 'apache.vhost.icinga2_web2.erb'
 default['icinga2']['apache_conf_cookbook'] = 'icinga2'

--- a/recipes/server_apache.rb
+++ b/recipes/server_apache.rb
@@ -53,7 +53,7 @@ template ::File.join(node['apache']['dir'], 'conf-available', "#{node['icinga2']
 end
 
 template ::File.join(node['apache']['dir'], 'conf-available', 'icinga2-web2.conf') do
-  source 'apache.vhost.icinga2_web2.erb'
+  source node['icinga2']['apache_web2_template']
   owner node['apache']['user']
   group node['apache']['group']
   cookbook node['icinga2']['apache_conf_cookbook']

--- a/recipes/server_apache.rb
+++ b/recipes/server_apache.rb
@@ -47,6 +47,7 @@ template ::File.join(node['apache']['dir'], 'conf-available', "#{node['icinga2']
   source "apache.vhost.icinga2_classic_ui.conf.#{apache_conf_file}.erb"
   owner node['apache']['user']
   group node['apache']['group']
+  cookbook node['icinga2']['apache_conf_cookbook']
   notifies platform?('windows') ? :restart : :reload, 'service[apache2]', :delayed
   only_if { node['icinga2']['classic_ui']['enable'] }
 end
@@ -55,6 +56,7 @@ template ::File.join(node['apache']['dir'], 'conf-available', 'icinga2-web2.conf
   source 'apache.vhost.icinga2_web2.erb'
   owner node['apache']['user']
   group node['apache']['group']
+  cookbook node['icinga2']['apache_conf_cookbook']
   notifies platform?('windows') ? :restart : :reload, 'service[apache2]', :delayed
   variables(:web_root => node['icinga2']['web2']['web_root'],
             :web_uri => node['icinga2']['web2']['web_uri'],


### PR DESCRIPTION
Current `server_apache.rb` use only htpasswd for user auth. This PR allow to customize Apache templates in wrapper cookbook and add external auth methods like LDAP, PAM, etc.