### PR TITLE
Set command_endpoint inspect

### DIFF
--- a/templates/default/object.host.conf.erb
+++ b/templates/default/object.host.conf.erb
@@ -70,7 +70,7 @@
   volatile = <%= options['volatile'].inspect %>
   <%- end -%>
   <%- if options['command_endpoint'] -%>
-  command_endpoint = <%= options['command_endpoint'] %>
+  command_endpoint = <%= options['command_endpoint'].inspect %>
   <%- end -%>
   <%- if options['notes'] -%>
   notes = <%= options['notes'].inspect %>

--- a/templates/default/object.service.conf.erb
+++ b/templates/default/object.service.conf.erb
@@ -67,7 +67,7 @@
   volatile = <%= options['volatile'].inspect %>
   <%- end -%>
   <%- if options['command_endpoint'] -%>
-  command_endpoint = <%= options['command_endpoint'] %>
+  command_endpoint = <%= options['command_endpoint'].inspect %>
   <%- end -%>
   <%- if options['notes'] -%>
   notes = <%= options['notes'].inspect %>


### PR DESCRIPTION
Hello,

Can somebody explain my why `command_endpoint` doesn't have `inspect`? I get errors then I define resource like
```
  icinga2_service "testhost_ssh" do
    import 'check-service-tmpl-1m'
    display_name 'ssh'
    host_name testhost
    max_check_attempts 4
    check_command 'ssh'
    zone 'icinga-master'
    command_endpoint 'icinga-master'
  end
```
