### PR TITLE
Fix icinga2 cache dir

### DIFF
--- a/templates/default/icinga2.service.config.erb
+++ b/templates/default/icinga2.service.config.erb
@@ -13,3 +13,4 @@ ICINGA2_LOG=<%= @log_dir -%>/icinga2.log
 ICINGA2_USER=<%= @user %>
 ICINGA2_GROUP=<%= @group %>
 ICINGA2_COMMAND_GROUP=<%= @cmdgroup %>
+ICINGA2_CACHE_DIR=$ICINGA2_STATE_DIR/cache/icinga2


### PR DESCRIPTION
This PR fix /etc/sysconfig/icinga2 for RHEL. Without shell env`ICINGA2_CACHE_DIR` icinga2 init script fails on start. The problem is in `prepare-dirs`:
```
$ /usr/lib/icinga2/prepare-dirs /etc/sysconfig/icinga2
mkdir: missing operand
Try 'mkdir --help' for more information.
chown: missing operand after ‘icinga:icinga’
Try 'chown --help' for more information.
chmod: missing operand after ‘750’
Try 'chmod --help' for more information.
```

icinga2 version
```
 icinga2-common-2.7.1-1.el7.icinga.x86_64
```