### PR TITLE
Fix ssl_enable attr for influxdbwriter

### DIFF
--- a/libraries/resource_influxdbwriter.rb
+++ b/libraries/resource_influxdbwriter.rb
@@ -67,7 +67,7 @@ class Chef
       def ssl_enable(arg = nil)
         set_or_return(
           :ssl_enable, arg,
-          :kind_of => String,
+          :kind_of => [TrueClass, FalseClass],
           :default => false
         )
       end


### PR DESCRIPTION
Influxdbwriter resource fails with error: 
```
Chef::Exceptions::ValidationFailed
         ----------------------------------
         Option ssl_enable must be a kind of [String]!  You passed false.`
```

This PR fixes it.

Chef client 13.x.