### PR TITLE
Allow version pinning when installing Icinga2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   # require_chef_omnibus: 12.21.4
   attributes:
     icinga2:
-      ignore_version: true
+      ignore_version: false
     apt:
       compile_time_update: true
       # temp fix

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,9 +2,9 @@
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/getting-started#getting-started
 
 default['icinga2']['version'] = value_for_platform(
-  %w(centos redhat fedora amazon) => { 'default' => '2.8.0-1' },
-  %w(debian ubuntu raspbian) => { 'default' => '2.8.0-1' },
-  %w(windows) => { 'default' => '2.8.0' }
+  %w(centos redhat fedora amazon) => { 'default' => '2.8.4-1' },
+  %w(debian ubuntu raspbian) => { 'default' => '2.8.4-1' },
+  %w(windows) => { 'default' => '2.8.4' }
 )
 default['icinga2']['ignore_version'] = false
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,6 +32,29 @@ unless platform?('windows')
   end
 end
 
+case node['platform_family']
+when 'debian'
+  package 'libicinga2' do
+    version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
+    action :install
+  end
+end
+
+package 'icinga2-doc' do
+  version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
+  action :install
+end
+
+package 'icinga2-common' do
+  version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
+  action :install
+end
+
+package 'icinga2-bin' do
+  version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
+  action :install
+end
+
 package 'icinga2' do
   version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
   notifies :restart, 'service[icinga2]', :delayed


### PR DESCRIPTION
Because of the way the icinga2 repo (at least on apt, but this has also been tested and passed on yum) when trying to install icinga2 and specifying a version, its dependencies try to install newer versions which breaks the install. By installing each dependency one by one with the version pinned, the proper version specified can be installed. All kitchen tests are passing.