### PR TITLE
Feature: add socket_path to `icinga2_idopgsqlconnection` and `icinga2_idomysqlconnection` custom resources

### DIFF
--- a/LWRP.md
+++ b/LWRP.md
@@ -1116,6 +1116,7 @@ icinga2_idomysqlconnection 'idomysqlconnection' do
   user 'user name'
   password 'password'
   database 'database name'
+  socket_path '/var/lib/mysql/mysql.sock'
 end
 ```
 
@@ -1156,6 +1157,7 @@ icinga2_idopgsqlconnection 'idopgsqlconnection' do
   user 'user name'
   password 'password'
   database 'database name'
+  socket_path '/tmp/.s.PGSQL.nnnn'
 end
 ```
 

--- a/libraries/resource_idomysqlconnection.rb
+++ b/libraries/resource_idomysqlconnection.rb
@@ -56,6 +56,14 @@ class Chef
         )
       end
 
+      def socket_path(arg = nil)
+        set_or_return(
+          :socket_path, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
       def database(arg = nil)
         set_or_return(
           :database, arg,
@@ -159,6 +167,7 @@ class Chef
                     :user => new_resource.user,
                     :password => new_resource.password,
                     :database => new_resource.database,
+                    :socket_path => new_resource.socket_path,
                     :table_prefix => new_resource.table_prefix,
                     :instance_name => new_resource.instance_name,
                     :instance_description => new_resource.instance_description,

--- a/libraries/resource_idopgsqlconnection.rb
+++ b/libraries/resource_idopgsqlconnection.rb
@@ -64,6 +64,14 @@ class Chef
         )
       end
 
+      def socket_path(arg = nil)
+        set_or_return(
+          :socket_path, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
       def table_prefix(arg = nil)
         set_or_return(
           :table_prefix, arg,
@@ -159,6 +167,7 @@ class Chef
                     :user => new_resource.user,
                     :password => new_resource.password,
                     :database => new_resource.database,
+                    :socket_path => new_resource.socket_path,
                     :table_prefix => new_resource.table_prefix,
                     :instance_name => new_resource.instance_name,
                     :instance_description => new_resource.instance_description,

--- a/templates/default/object.idomysqlconnection.conf.erb
+++ b/templates/default/object.idomysqlconnection.conf.erb
@@ -25,6 +25,9 @@ object IdoMysqlConnection <%= @object.inspect -%> {
   <% if @database -%>
   database = <%= @database.inspect %>
   <% end -%>
+  <% if @socket_path -%>
+  socket_path = <%= @socket_path.inspect %>
+  <% end -%>
   <% if @table_prefix -%>
   table_prefix = <%= @table_prefix.inspect %>
   <% end -%>

--- a/templates/default/object.idopgsqlconnection.conf.erb
+++ b/templates/default/object.idopgsqlconnection.conf.erb
@@ -25,6 +25,9 @@ object IdoPgsqlConnection <%= @object.inspect -%> {
   <% if @database -%>
   database = <%= @database.inspect %>
   <% end -%>
+  <% if @socket_path -%>
+  socket_path = <%= @socket_path.inspect %>
+  <% end -%>
   <% if @table_prefix -%>
   table_prefix = <%= @table_prefix.inspect %>
   <% end -%>


### PR DESCRIPTION
### Problem

With the existing `icinga2_idopgsqlconnection` and `icinga2_idomysqlconnection` custom resources, you are unable to set the [`socket_path`](https://www.icinga.com/docs/icinga2/latest/doc/09-object-types/#objecttype-idomysqlconnection) option in the object.

While I was using the [chef-icingaweb2](https://github.com/Icinga/chef-icingaweb2/blob/master/recipes/ido.rb#L113) cookbook, it does not set `socket_path`, so it defaults to `/var/lib/mysql/mysql.sock` when `host` is set to `localhost`.

### Justification

Users may need to specify where there socket is located if they don't want to open up permissions to `/var/lib/mysql` or they have a non-standard socket path.

### Solution

Add the `socket_path` variable to both `icinga2_idopgsqlconnection` and `icinga2_idomysqlconnection` custom resources and their templates.

I didn't see any specific testing in place for the custom resource, so please let me know if I need to add a test or two.