### PR TITLE
Make test kitchen tests pass

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,9 +2,9 @@
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/getting-started#getting-started
 
 default['icinga2']['version'] = value_for_platform(
-  %w(centos redhat fedora amazon) => { 'default' => '2.8.4-1' },
-  %w(debian ubuntu raspbian) => { 'default' => '2.8.4-1' },
-  %w(windows) => { 'default' => '2.8.4' }
+  %w(centos redhat fedora amazon) => { 'default' => '2.10.1-1' },
+  %w(debian ubuntu raspbian) => { 'default' => '2.10.1-1' },
+  %w(windows) => { 'default' => '2.10.1' }
 )
 default['icinga2']['ignore_version'] = false
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -32,25 +32,17 @@ unless platform?('windows')
   end
 end
 
-case node['platform_family']
-when 'debian'
-  package 'libicinga2' do
-    version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
-    action :install
-  end
-end
-
 package 'icinga2-doc' do
   version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
   action :install
 end
 
-package 'icinga2-common' do
+package 'icinga2-bin' do
   version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
   action :install
 end
 
-package 'icinga2-bin' do
+package 'icinga2-common' do
   version node['icinga2']['version'] + node['icinga2']['version_suffix'] unless node['icinga2']['ignore_version']
   action :install
 end

--- a/test/smoke/server/default_test.rb
+++ b/test/smoke/server/default_test.rb
@@ -17,16 +17,6 @@ describe package('icinga2-bin') do
   it { should be_installed }
 end
 
-if %w(redhat fedora amazon).include?(os[:family])
-  describe package('icinga2-libs') do
-    it { should be_installed }
-  end
-else
-  describe package('libicinga2') do
-    it { should be_installed }
-  end
-end
-
 describe service('icinga2') do
   it { should be_installed }
   it { should be_enabled }


### PR DESCRIPTION
I did some work on the icinga2 cookbook to get the tests passing in test kitchen. It looks like the lib package is no longer needed as I got messages saying that it is obsoleted by the bin package. Updated the version numbers and I had to change the order of the package installs to get it to work on debian and later Ubuntu versions.

Tests should pass now in test kitchen.