### PR TITLE
Updates to support the latest release (v2.10)

### DIFF
--- a/LWRP.md
+++ b/LWRP.md
@@ -1329,7 +1329,7 @@ LWRP `notificationcommand` creates an icinga `NotificationCommand` object.
 
 ```ruby
 icinga2_notificationcommand 'mail-service-notification' do
-  command ['SysconfDir + "/icinga2/scripts/mail-service-notification.sh"']
+  command ['ConfigDir + "/icinga2/scripts/mail-service-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
     'SERVICEDESC' => '$service.name$',\
     'HOSTALIAS' => '$host.display_name$',\
@@ -1370,9 +1370,9 @@ LWRP `apilistener` creates an icinga `ApiListener` object.
 
 ```ruby
 icinga2_apilistener 'master' do
-  cert_path 'SysconfDir + "/icinga2/pki/" + NodeName + ".crt"'
-  key_path 'SysconfDir + "/icinga2/pki/" + NodeName + ".key"'
-  ca_path 'SysconfDir + "/icinga2/pki/ca.crt"'
+  cert_path 'ConfigDir + "/icinga2/pki/" + NodeName + ".crt"'
+  key_path 'ConfigDir + "/icinga2/pki/" + NodeName + ".key"'
+  ca_path 'ConfigDir + "/icinga2/pki/ca.crt"'
   bind_host 'host address'
   bind_port '5665'
   ticket_salt 'TicketSalt'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,9 +2,9 @@
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/getting-started#getting-started
 
 default['icinga2']['version'] = value_for_platform(
-  %w(centos redhat fedora amazon) => { 'default' => '2.8.4-1' },
-  %w(debian ubuntu raspbian) => { 'default' => '2.8.4-1' },
-  %w(windows) => { 'default' => '2.8.4' }
+  %w(centos redhat fedora amazon) => { 'default' => '2.10.0-1' },
+  %w(debian ubuntu raspbian) => { 'default' => '2.10.0-1' },
+  %w(windows) => { 'default' => '2.10.0' }
 )
 default['icinga2']['ignore_version'] = false
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,9 +2,9 @@
 # http://docs.icinga.org/icinga2/latest/doc/module/icinga2/chapter/getting-started#getting-started
 
 default['icinga2']['version'] = value_for_platform(
-  %w(centos redhat fedora amazon) => { 'default' => '2.10.0-1' },
-  %w(debian ubuntu raspbian) => { 'default' => '2.10.0-1' },
-  %w(windows) => { 'default' => '2.10.0' }
+  %w(centos redhat fedora amazon) => { 'default' => '2.10.1-1' },
+  %w(debian ubuntu raspbian) => { 'default' => '2.10.1-1' },
+  %w(windows) => { 'default' => '2.10.1' }
 )
 default['icinga2']['ignore_version'] = false
 

--- a/examples/icinga2_server/recipes/notificationcommand.rb
+++ b/examples/icinga2_server/recipes/notificationcommand.rb
@@ -19,7 +19,7 @@
 #
 
 icinga2_notificationcommand 'mail-service-notification' do
-  command ['SysconfDir + "/icinga2/scripts/mail-service-notification.sh"']
+  command ['ConfigDir + "/icinga2/scripts/mail-service-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
       'SERVICEDESC' => '$service.name$',\
       'HOSTALIAS' => '$host.display_name$',\
@@ -35,7 +35,7 @@ icinga2_notificationcommand 'mail-service-notification' do
 end
 
 icinga2_notificationcommand 'mail-host-notification' do
-  command ['SysconfDir + "/icinga2/scripts/mail-host-notification.sh"']
+  command ['ConfigDir + "/icinga2/scripts/mail-host-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$',
       'HOSTALIAS' => '$host.display_name$',
       'HOSTADDRESS' => '$address$',

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -37,6 +37,7 @@ end
 [
   node['icinga2']['log_dir'],
   node['icinga2']['run_dir'],
+  node['icinga2']['run_cmd_dir'],
   ::File.join(node['icinga2']['log_dir'], 'compat'),
   ::File.join(node['icinga2']['log_dir'], 'compat', 'archives'),
 ].each do |d|

--- a/recipes/objects.rb
+++ b/recipes/objects.rb
@@ -50,7 +50,7 @@ end
 
 # notificationcommand objects
 icinga2_notificationcommand 'mail-service-notification' do
-  command ['SysconfDir + "/icinga2/scripts/mail-service-notification.sh"']
+  command ['ConfigDir + "/icinga2/scripts/mail-service-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
       'SERVICEDESC' => '$service.name$',\
       'HOSTALIAS' => '$host.display_name$',\
@@ -67,7 +67,7 @@ icinga2_notificationcommand 'mail-service-notification' do
 end
 
 icinga2_notificationcommand 'mail-host-notification' do
-  command ['SysconfDir + "/icinga2/scripts/mail-host-notification.sh"']
+  command ['ConfigDir + "/icinga2/scripts/mail-host-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
       'SERVICEDESC' => '$service.name$',\
       'HOSTALIAS' => '$host.display_name$',\

--- a/templates/default/icinga2.service.config.erb
+++ b/templates/default/icinga2.service.config.erb
@@ -7,7 +7,7 @@ ICINGA2_CONFIG_FILE=<%= @conf_dir -%>/icinga2.conf
 # V2.9 and below
 ICINGA2_RUN_DIR=/var/run
 # v2.10 and greater
-ICINGA2_INIT_RUN_DIR=/var/run
+ICINGA2_INIT_RUN_DIR=/var/run/icinga2
 ICINGA2_STATE_DIR=/var
 ICINGA2_PID_FILE=$ICINGA2_RUN_DIR/icinga2/icinga2.pid
 ICINGA2_ERROR_LOG=<%= @log_dir -%>/error.log

--- a/templates/default/icinga2.service.config.erb
+++ b/templates/default/icinga2.service.config.erb
@@ -4,7 +4,10 @@
 #
 DAEMON=/usr/sbin/icinga2
 ICINGA2_CONFIG_FILE=<%= @conf_dir -%>/icinga2.conf
+# V2.9 and below
 ICINGA2_RUN_DIR=/var/run
+# v2.10 and greater
+ICINGA2_INIT_RUN_DIR=/var/run
 ICINGA2_STATE_DIR=/var
 ICINGA2_PID_FILE=$ICINGA2_RUN_DIR/icinga2/icinga2.pid
 ICINGA2_ERROR_LOG=<%= @log_dir -%>/error.log

--- a/test/smoke/server/default_test.rb
+++ b/test/smoke/server/default_test.rb
@@ -17,16 +17,6 @@ describe package('icinga2-bin') do
   it { should be_installed }
 end
 
-if %w(redhat fedora amazon).include?(os[:family])
-  describe package('icinga2-libs') do
-    it { should be_installed }
-  end
-else
-  describe package('libicinga2') do
-    it { should be_installed }
-  end
-end
-
 describe service('icinga2') do
   it { should be_installed }
   it { should be_enabled }

--- a/test/smoke/web2/default_test.rb
+++ b/test/smoke/web2/default_test.rb
@@ -17,16 +17,6 @@ describe package('icinga2-bin') do
   it { should be_installed }
 end
 
-if %w(redhat fedora amazon).include?(os[:family])
-  describe package('icinga2-libs') do
-    it { should be_installed }
-  end
-else
-  describe package('libicinga2') do
-    it { should be_installed }
-  end
-end
-
 describe service('icinga2') do
   it { should be_installed }
   it { should be_enabled }


### PR DESCRIPTION
Includes some minor compatibility changes, and moves the default Icinga version to 2.10. Needed for this cookbook to work out of the box, as the older builds have been dropped from the repo.

I didn't update icingaweb because that seemed to be more involved, and the old version still works.