### PR TITLE
Fix mail notifications- update paths constructed from ConfigDir to match the v2.10 changes

### DIFF
--- a/LWRP.md
+++ b/LWRP.md
@@ -1329,7 +1329,7 @@ LWRP `notificationcommand` creates an icinga `NotificationCommand` object.
 
 ```ruby
 icinga2_notificationcommand 'mail-service-notification' do
-  command ['ConfigDir + "/icinga2/scripts/mail-service-notification.sh"']
+  command ['ConfigDir + "/scripts/mail-service-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
     'SERVICEDESC' => '$service.name$',\
     'HOSTALIAS' => '$host.display_name$',\
@@ -1370,9 +1370,9 @@ LWRP `apilistener` creates an icinga `ApiListener` object.
 
 ```ruby
 icinga2_apilistener 'master' do
-  cert_path 'ConfigDir + "/icinga2/pki/" + NodeName + ".crt"'
-  key_path 'ConfigDir + "/icinga2/pki/" + NodeName + ".key"'
-  ca_path 'ConfigDir + "/icinga2/pki/ca.crt"'
+  cert_path 'ConfigDir + "/pki/" + NodeName + ".crt"'
+  key_path 'ConfigDir + "/pki/" + NodeName + ".key"'
+  ca_path 'ConfigDir + "/pki/ca.crt"'
   bind_host 'host address'
   bind_port '5665'
   ticket_salt 'TicketSalt'

--- a/examples/icinga2_server/recipes/notificationcommand.rb
+++ b/examples/icinga2_server/recipes/notificationcommand.rb
@@ -19,7 +19,7 @@
 #
 
 icinga2_notificationcommand 'mail-service-notification' do
-  command ['ConfigDir + "/icinga2/scripts/mail-service-notification.sh"']
+  command ['ConfigDir + "/scripts/mail-service-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
       'SERVICEDESC' => '$service.name$',\
       'HOSTALIAS' => '$host.display_name$',\
@@ -35,7 +35,7 @@ icinga2_notificationcommand 'mail-service-notification' do
 end
 
 icinga2_notificationcommand 'mail-host-notification' do
-  command ['ConfigDir + "/icinga2/scripts/mail-host-notification.sh"']
+  command ['ConfigDir + "/scripts/mail-host-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$',
       'HOSTALIAS' => '$host.display_name$',
       'HOSTADDRESS' => '$address$',

--- a/recipes/objects.rb
+++ b/recipes/objects.rb
@@ -50,7 +50,7 @@ end
 
 # notificationcommand objects
 icinga2_notificationcommand 'mail-service-notification' do
-  command ['ConfigDir + "/icinga2/scripts/mail-service-notification.sh"']
+  command ['ConfigDir + "/scripts/mail-service-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
       'SERVICEDESC' => '$service.name$',\
       'HOSTALIAS' => '$host.display_name$',\
@@ -67,7 +67,7 @@ icinga2_notificationcommand 'mail-service-notification' do
 end
 
 icinga2_notificationcommand 'mail-host-notification' do
-  command ['ConfigDir + "/icinga2/scripts/mail-host-notification.sh"']
+  command ['ConfigDir + "/scripts/mail-host-notification.sh"']
   env 'NOTIFICATIONTYPE' => '$notification.type$', \
       'SERVICEDESC' => '$service.name$',\
       'HOSTALIAS' => '$host.display_name$',\


### PR DESCRIPTION
I managed to really bobble this in #332- see [the documentation](https://github.com/Icinga/icinga2/blob/master/doc/16-upgrading-icinga-2.md#path-constant-changes-) for the warning about the new ConfigDir variable. Anything that uses it needs to be changed to be relative to SysconfDir+"/icinga2/"-

```
object NotificationCommand "mail-service-notification" {
-  command = [ SysconfDir + "/icinga2/scripts/mail-service-notification.sh" ]
+  command = [ ConfigDir + "/scripts/mail-service-notification.sh" ]
```

being the example diff. This will finish the transition in this cookbook.

Without this, if you use the examples, you will get errors in the logs that look like
```
terminated with exit code 128, output: execvpe(/etc/icinga2/icinga2/scripts/mail-service-notification.sh) failed: No such file or directory
```

and notifications will not work.